### PR TITLE
Delete VendorDescription from all files

### DIFF
--- a/model/src/main/proto/javaclasses/mealorder/c/commands.proto
+++ b/model/src/main/proto/javaclasses/mealorder/c/commands.proto
@@ -30,11 +30,13 @@ option java_outer_classname = "CommandsProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
+
+import "google/protobuf/timestamp.proto";
+import "spine/net/email_address.proto";
+import "spine/time/time.proto";
 import "javaclasses/mealorder/identifiers.proto";
 import "javaclasses/mealorder/values.proto";
 import "javaclasses/mealorder/model.proto";
-import "google/protobuf/timestamp.proto";
-
 
 // Add a new vendor.
 //
@@ -48,11 +50,17 @@ message AddVendor {
     // An identifier of the User, who added Vendor.
     UserId user_id = 2;
 
-    // Vendor description.
-    VendorDescription vendor_description = 3;
+    // Email adress  to send an purchase order.
+    spine.net.EmailAddress email = 3;
+
+    // Phone numbers of the vendor.
+    repeated PhoneNumber phone_numbers = 4;
+
+    // A daily deadline.
+    spine.time.LocalTime po_daily_deadline = 5;
 
     // Time of addition.
-    google.protobuf.Timestamp when_added = 4;
+    google.protobuf.Timestamp when_added = 6;
 }
 
 // Update vendor description.
@@ -65,16 +73,12 @@ message UpdateVendor {
     // An identifier of the User, who updates `Vendor`.
     UserId user_id = 2;
 
-    // The vendor description that's changing.
-    VendorDescription updated_vendor_description = 3;
-
-    // Previous vendor description.
-    VendorDescription previous_vendor_description = 4;
+    // Changes in vendor fields.
+    VendorChange vendor_change = 3;
 
     // Time of update.
-    google.protobuf.Timestamp when_updated = 5;
+    google.protobuf.Timestamp when_updated = 4;
 }
-
 
 // Import a menu.
 //

--- a/model/src/main/proto/javaclasses/mealorder/c/events.proto
+++ b/model/src/main/proto/javaclasses/mealorder/c/events.proto
@@ -41,19 +41,19 @@ import "javaclasses/mealorder/values.proto";
 //
 message VendorAdded {
 
-    // An identifier of the added Vendor.
+    // An identifier of the added vendor.
     VendorId vendor_id = 1;
 
-    // An identifier of the User, who added Vendor.
+    // An identifier of the user, who added vendor.
     UserId who_added = 2;
 
     // Time of addition.
     google.protobuf.Timestamp when_added = 3;
 
-    // Email adress  to send an purchase order.
+    // An email adress  to send an purchase order.
     spine.net.EmailAddress email = 4;
 
-    // Phone numbers of the vendor.
+    // A phone numbers of the vendor.
     repeated PhoneNumber phone_numbers = 5;
 
     // A daily deadline.
@@ -64,10 +64,10 @@ message VendorAdded {
 //
 message VendorUpdated {
 
-    // An identifier of the updated Vendor.
+    // An identifier of the updated vendor.
     VendorId vendor_id = 1;
 
-    // An identifier of the User, who updated Vendor.
+    // An identifier of the user, who updated vendor.
     UserId who_uploaded = 2;
 
     // Time of update.
@@ -87,10 +87,10 @@ message MenuImported {
     // An identifier of a vendor that provided a menu.
     VendorId vendor_id = 1;
 
-    // An identifier of imported Menu, contains VendorId.
+    // An identifier of imported menu, contains vendor ID.
     MenuId menu_id = 2;
 
-    // An identifier of the User, who imported Menu.
+    // An identifier of the user, who imported menu.
     UserId who_imported = 3;
 
     // Menu import time.
@@ -104,13 +104,13 @@ message MenuImported {
 //
 message DateRangeForMenuSet {
 
-    // An identifier of Menu.
+    // An identifier of the menu.
     MenuId menu_id = 1;
 
-    // An identifier of the User, who set MenuDateRange.
+    // An identifier of the user, who set menu date range.
     UserId who_set = 2;
 
-    // MenuDateRange setting time.
+    // Menu date range setting time.
     google.protobuf.Timestamp when_set = 3;
 
     // Menu date range that has been set.
@@ -181,7 +181,7 @@ message OrderProcessed {
 //
 message PurchaseOrderCreated {
 
-    // PurchaseOrder identifier.
+    // A Purchase order identifier.
     PurchaseOrderId id = 1;
 
     // Time of creation.
@@ -195,7 +195,7 @@ message PurchaseOrderCreated {
 //
 message PurchaseOrderDelivered {
 
-    // PurchaseOrder identifier.
+    // A Purchase order identifier.
     PurchaseOrderId id = 1;
 
     // Delivery time.
@@ -206,16 +206,16 @@ message PurchaseOrderDelivered {
 //
 message PurchaseOrderSent {
 
-    // PurchaseOrder identifier.
+    // A Purchase order identifier.
     PurchaseOrder purchase_order = 1;
 
     // Sending time.
     google.protobuf.Timestamp when_sent = 2;
 
-    // E-mail address of the sender.
+    // An E-mail address of the sender.
     spine.net.EmailAddress sender_email = 3;
 
-    // E-mail address of the recipient.
+    // An E-mail address of the recipient.
     spine.net.EmailAddress vendor_email = 4;
 }
 
@@ -223,7 +223,7 @@ message PurchaseOrderSent {
 //
 message PurchaseOrderValidationFailed {
 
-    // PurchaseOrder identifier.
+    // A purchase order identifier.
     PurchaseOrderId id = 1;
 
     // Collection of orders that caused the failure of validation.
@@ -237,10 +237,10 @@ message PurchaseOrderValidationFailed {
 //
 message PurchaseOrderValidationOverruled {
 
-    // PurchaseOrder identifier.
+    // A purchase order identifier.
     PurchaseOrderId id = 1;
 
-    // User identifiers that overruled the validation.
+    // A user identifiers that overruled the validation.
     UserId who_overruled = 2;
 
     // The reason why validation is overruled.
@@ -251,7 +251,7 @@ message PurchaseOrderValidationOverruled {
 //
 message PurchaseOrderValidationPassed {
 
-    // PurchaseOrder identifier.
+    // A purchase order identifier.
     PurchaseOrderId id = 1;
 
     // Time of successful validation.
@@ -262,7 +262,7 @@ message PurchaseOrderValidationPassed {
 //
 message PurchaseOrderCanceled {
 
-    // PurchaseOrder identifier.
+    // A purchase order identifier.
     PurchaseOrderId id = 1;
 
     // Cancellation time.

--- a/model/src/main/proto/javaclasses/mealorder/c/events.proto
+++ b/model/src/main/proto/javaclasses/mealorder/c/events.proto
@@ -30,13 +30,12 @@ option java_outer_classname = "EventsProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
+import "google/protobuf/timestamp.proto";
 import "spine/net/email_address.proto";
+import "spine/time/time.proto";
 import "javaclasses/mealorder/identifiers.proto";
 import "javaclasses/mealorder/model.proto";
 import "javaclasses/mealorder/values.proto";
-import "google/protobuf/timestamp.proto";
-
-
 
 // An event reflecting the vendor addition.
 //
@@ -51,8 +50,14 @@ message VendorAdded {
     // Time of addition.
     google.protobuf.Timestamp when_added = 3;
 
-    // Vendor description.
-    VendorDescription vendor_description = 4;
+    // Email adress  to send an purchase order.
+    spine.net.EmailAddress email = 4;
+
+    // Phone numbers of the vendor.
+    repeated PhoneNumber phone_numbers = 5;
+
+    // A daily deadline.
+    spine.time.LocalTime po_daily_deadline = 6;
 }
 
 // An event fired upon the vendor description update.
@@ -68,11 +73,8 @@ message VendorUpdated {
     // Time of update.
     google.protobuf.Timestamp when_updated = 3;
 
-    // Updated vendor description.
-    VendorDescription updated_vendor_description = 4;
-
-    // Previous vendor description.
-    VendorDescription previous_vendor_description = 5;
+    // Changes in vendor fields.
+    VendorChange vendor_change = 4;
 }
 
 // An event signalizing about the successful import of the menu.

--- a/model/src/main/proto/javaclasses/mealorder/identifiers.proto
+++ b/model/src/main/proto/javaclasses/mealorder/identifiers.proto
@@ -37,7 +37,7 @@ import "spine/time/time.proto";
 
 // An ID of a user.
 //
-// An identifier is represented by User email address of the next type:
+// An identifier is represented by user email address of the next type:
 // <Name>.<Surname>@teamdev.com
 //
 message UserId {
@@ -60,7 +60,7 @@ message VendorId {
 
 // An ID of an order.
 //
-// An identifier is represented by VendorId, UserId and order date.
+// An identifier is represented by vendor ID, user ID and order date.
 //
 message OrderId {
 
@@ -70,13 +70,13 @@ message OrderId {
     // An identifier of a user who makes an order.
     UserId user_id = 2;
 
-    // A Date of the order.
+    // A date of the order.
     spine.time.LocalDate order_date = 3;
 }
 
 // An ID of a menu.
 //
-// An identifier is represented by VendorId and imported time.
+// An identifier is represented by vendor ID and imported time.
 //
 message MenuId {
 
@@ -100,15 +100,15 @@ message DishId {
     MenuId menu_id = 2;
 }
 
-// An ID of a purchase order. represented by VendorId and purchase order date.
+// An ID of a purchase order. represented by vendor ID and purchase order date.
 //
-// An identifier is represented by VendorId and purchase order date.
+// An identifier is represented by vendor ID and purchase order date.
 //
 message PurchaseOrderId {
 
     // An identifier of a vendor.
     VendorId vendor_id = 1;
 
-    // Date on which this purchase order is formed.
+    // A date on which this purchase order is formed.
     google.protobuf.Timestamp po_date = 2;
 }

--- a/model/src/main/proto/javaclasses/mealorder/identifiers.proto
+++ b/model/src/main/proto/javaclasses/mealorder/identifiers.proto
@@ -52,8 +52,10 @@ message UserId {
 //
 message VendorId {
 
-    // A name of a vendor.
-    string vendor_name = 1;
+    // String representation of UUID.
+    //
+    // Automatically generated upon vendor creation.
+    string value = 1;
 }
 
 // An ID of an order.

--- a/model/src/main/proto/javaclasses/mealorder/model.proto
+++ b/model/src/main/proto/javaclasses/mealorder/model.proto
@@ -33,6 +33,8 @@ option java_generate_equals_and_hash = true;
 import "javaclasses/mealorder/identifiers.proto";
 import "javaclasses/mealorder/values.proto";
 import "spine/money/money.proto";
+import "spine/time/time.proto";
+import "spine/net/email_address.proto";
 
 // The model representing a dish.
 //
@@ -97,6 +99,14 @@ message Vendor {
     // An identifier of the vendor.
     VendorId id = 1;
 
-    // Additional information about the vendor.
-    VendorDescription description = 2;
+    VendorName vendor_name = 2;
+
+    // Email adress  to send an purchase order.
+    spine.net.EmailAddress email = 3;
+
+    // Phone numbers of the vendor.
+    repeated PhoneNumber phone_numbers = 4;
+
+    // A daily deadline.
+    spine.time.LocalTime po_daily_deadline = 5;
 }

--- a/model/src/main/proto/javaclasses/mealorder/model.proto
+++ b/model/src/main/proto/javaclasses/mealorder/model.proto
@@ -101,7 +101,7 @@ message Vendor {
 
     VendorName vendor_name = 2;
 
-    // Email adress  to send an purchase order.
+    // An email adress  to send an purchase order.
     spine.net.EmailAddress email = 3;
 
     // Phone numbers of the vendor.

--- a/model/src/main/proto/javaclasses/mealorder/q/projections.proto
+++ b/model/src/main/proto/javaclasses/mealorder/q/projections.proto
@@ -30,11 +30,12 @@ option java_outer_classname = "ProjectionsProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
-import "javaclasses/mealorder/identifiers.proto";
-import "javaclasses/mealorder/values.proto";
 import "google/protobuf/timestamp.proto";
 import "spine/time/time.proto";
 import "spine/money/money.proto";
+import "spine/net/email_address.proto";
+import "javaclasses/mealorder/identifiers.proto";
+import "javaclasses/mealorder/values.proto";
 
 // **** User interface projections ****
 
@@ -162,7 +163,14 @@ message VendorItem {
 
     VendorId id = 1;
 
-    VendorDescription description = 2;
+    // Email adress  to send an purchase order.
+    spine.net.EmailAddress email = 3;
+
+    // Phone numbers of the vendor.
+    repeated PhoneNumber phone_numbers = 4;
+
+    // A daily deadline.
+    spine.time.LocalTime po_daily_deadline = 5;
 }
 
 // A projection state of menu list for administrator interface.

--- a/model/src/main/proto/javaclasses/mealorder/values.proto
+++ b/model/src/main/proto/javaclasses/mealorder/values.proto
@@ -66,22 +66,22 @@ message VendorName {
 //
 message VendorChange {
 
-    // Email adress that's changing.
+    // An email adress that's changing.
     spine.net.EmailAddress previous_email = 1;
 
-    // Phone numbers that's changing.
+    // A phone numbers that's changing.
     repeated PhoneNumber previous_phone_numbers = 2;
 
     // A daily deadline that's changing.
     spine.time.LocalTime previous_po_daily_deadline = 3;
 
-    // The new e-mail adress.
+    // A new e-mail adress.
     spine.net.EmailAddress new_email = 4;
 
-    // The new phone numbers of the vendor.
+    // A new phone numbers of the vendor.
     repeated PhoneNumber new_phone_numbers = 5;
 
-    // The new daily deadline.
+    // A new daily deadline.
     spine.time.LocalTime new_po_daily_deadline = 6;
 
 }

--- a/model/src/main/proto/javaclasses/mealorder/values.proto
+++ b/model/src/main/proto/javaclasses/mealorder/values.proto
@@ -55,21 +55,35 @@ message PhoneNumber {
     string value = 1;
 }
 
-// The model that represents vendor description.
+// The model that represents vendor name.
 //
-// Vendor description it is email, pnone numbers and daily deadline.
-// After reaching deadline, the order will not be accepted.
+message VendorName {
+    // The name of the vendor, unique for each vendor.
+    string value = 1;
+}
+
+// Definition of a change in a vendor fields.
 //
-message VendorDescription {
+message VendorChange {
 
-    // Email adress  to send an purchase order.
-    spine.net.EmailAddress email = 1;
+    // Email adress that's changing.
+    spine.net.EmailAddress previous_email = 1;
 
-    // Phone numbers of the vendor.
-    repeated PhoneNumber phone_numbers = 2;
+    // Phone numbers that's changing.
+    repeated PhoneNumber previous_phone_numbers = 2;
 
-    // A daily deadline.
-    spine.time.LocalTime po_daily_deadline = 3;
+    // A daily deadline that's changing.
+    spine.time.LocalTime previous_po_daily_deadline = 3;
+
+    // The new e-mail adress.
+    spine.net.EmailAddress new_email = 4;
+
+    // The new phone numbers of the vendor.
+    repeated PhoneNumber new_phone_numbers = 5;
+
+    // The new daily deadline.
+    spine.time.LocalTime new_po_daily_deadline = 6;
+
 }
 
 // DTO for the rejected add vendor command details.


### PR DESCRIPTION
- `VendorDescription` was replaced by three values:
`EmailAddress`, collection of `PhoneNumber` and `LocalTime` with daily deadline for purchase order.

- The identifier for the vendor was replaced with an automatically generated UUID.

