### PR TITLE
Add tests for the VendorAggregateRejections.

### DIFF
--- a/api-java/src/main/java/javaclasses/mealorder/c/aggregate/VendorAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/aggregate/VendorAggregate.java
@@ -46,8 +46,8 @@ import java.util.stream.IntStream;
 import static io.spine.time.Time.getCurrentTime;
 import static javaclasses.mealorder.c.aggregate.VendorValidator.isThereMenuForThisDateRange;
 import static javaclasses.mealorder.c.aggregate.VendorValidator.isValidDateRange;
-import static javaclasses.mealorder.c.aggregate.rejection.VendorAggregateRejections.UpdateRejections.throwCannotSetDateRange;
-import static javaclasses.mealorder.c.aggregate.rejection.VendorAggregateRejections.UpdateRejections.throwVendorAlreadyExists;
+import static javaclasses.mealorder.c.aggregate.rejection.VendorAggregateRejections.throwCannotSetDateRange;
+import static javaclasses.mealorder.c.aggregate.rejection.VendorAggregateRejections.throwVendorAlreadyExists;
 
 /**
  * The aggregate managing the state of a {@link Vendor}.

--- a/api-java/src/main/java/javaclasses/mealorder/c/aggregate/rejection/VendorAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/aggregate/rejection/VendorAggregateRejections.java
@@ -39,10 +39,6 @@ public class VendorAggregateRejections {
         // Prevent instantiation of this utility class.
     }
 
-    public static class UpdateRejections {
-
-        private UpdateRejections() {
-        }
 
         /**
          * Constructs and throws the {@link VendorAlreadyExists} rejection
@@ -69,5 +65,4 @@ public class VendorAggregateRejections {
                                          getCurrentTime());
         }
 
-    }
 }

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/VendorValidatorTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/VendorValidatorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.mealorder.c.aggregate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+
+/**
+ * @author Yurii Haidamaka
+ */
+@DisplayName("VendorValidator should")
+public class VendorValidatorTest {
+
+    @Test
+    @DisplayName("have the private constructor")
+    public void havePrivateConstructor() {
+        assertHasPrivateParameterlessCtor(VendorValidator.class);
+    }
+}

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/rejection/VendorAggregateRejectionsTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/rejection/VendorAggregateRejectionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.mealorder.c.aggregate.rejection;
+
+import javaclasses.mealorder.c.command.AddVendor;
+import javaclasses.mealorder.c.command.SetDateRangeForMenu;
+import javaclasses.mealorder.c.rejection.CannotSetDateRange;
+import javaclasses.mealorder.c.rejection.VendorAlreadyExists;
+import javaclasses.mealorder.testdata.TestVendorCommandFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static javaclasses.mealorder.c.aggregate.rejection.VendorAggregateRejections.throwCannotSetDateRange;
+import static javaclasses.mealorder.c.aggregate.rejection.VendorAggregateRejections.throwVendorAlreadyExists;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Yurii Haidamaka
+ */
+@DisplayName("VendorAggregateRejections should")
+class VendorAggregateRejectionsTest {
+
+    @Test
+    @DisplayName("have the private constructor")
+    void havePrivateConstructor() {
+        assertHasPrivateParameterlessCtor(VendorAggregateRejections.class);
+    }
+
+    @Test
+    @DisplayName("throw VendorAlreadyExists rejection")
+    void throwVendorAlreadyExistsRejection() {
+        final AddVendor cmd = TestVendorCommandFactory.addVendorInstance();
+        final VendorAlreadyExists rejection = assertThrows(VendorAlreadyExists.class,
+                                                           () -> throwVendorAlreadyExists(cmd));
+
+        assertEquals(cmd.getVendorId(), rejection.getMessageThrown()
+                                                 .getVendorId());
+        assertEquals(cmd.getVendorName(), rejection.getMessageThrown()
+                                                   .getVendorName());
+    }
+
+    @Test
+    @DisplayName("throw CannotSetDateRange rejection")
+    void throwCannotSetDateRangeRejection() {
+        SetDateRangeForMenu cmd = TestVendorCommandFactory.setDateRangeForMenuInstance();
+        final CannotSetDateRange rejection =
+                assertThrows(CannotSetDateRange.class,
+                             () -> throwCannotSetDateRange(cmd));
+
+        assertEquals(cmd.getVendorId(), rejection.getMessageThrown()
+                                                 .getVendorId());
+        assertEquals(cmd.getMenuId(), rejection.getMessageThrown()
+                                               .getMenuId());
+        assertEquals(cmd.getMenuDateRange(), rejection.getMessageThrown()
+                                                      .getMenuDateRange());
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'idea'
 
-    group = 'io.spine.examples.todolist'       // Generated output GroupId
+    group = 'javaclasses.mealorder'       // Generated output GroupId
     version = appVersion  // Version in generated output. This is the version of the code.
     // For the deployment version see `project.ext.getDeploymentVersion`.
 


### PR DESCRIPTION
Before this PR we had VendorAggregate class with handler methods.
During processing `AddVendor` and `SetMEnuDateRange` commands there were exceptions :
- `VendorAlreadyExists`
- `CannotSetDateRange`

When processing these exceptions, we used methods `throwVendorAlreadyExists()` and `throwCannotSetDateRange()`.
In this PR we added tests that verify the correctness of these methods.
 