### PR TITLE
Add collection of orders to POcanceled event.

### DIFF
--- a/api-java/src/main/java/javaclasses/mealorder/c/aggregate/PurchaseOrderAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/aggregate/PurchaseOrderAggregate.java
@@ -173,7 +173,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
         if (!isAllowedToCancel()) {
             throwCannotCancelDeliveredPurchaseOrder(cmd);
         }
-        return createPOCanceledEvent(cmd);
+        return createPOCanceledEvent(cmd, getState().getOrdersList());
     }
 
     /*
@@ -282,11 +282,13 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
                                      .build();
     }
 
-    private static PurchaseOrderCanceled createPOCanceledEvent(CancelPurchaseOrder cmd) {
+    private static PurchaseOrderCanceled createPOCanceledEvent(CancelPurchaseOrder cmd,
+                                                               List<Order> orders) {
         final PurchaseOrderCanceled.Builder builder = PurchaseOrderCanceled
                 .newBuilder()
                 .setId(cmd.getId())
                 .setUserId(cmd.getUserId())
+                .addAllOrder(orders)
                 .setWhenCanceled(getCurrentTime());
 
         switch (cmd.getReasonCase()) {

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/po/CancelPurchaseOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/po/CancelPurchaseOrderTest.java
@@ -23,7 +23,6 @@ package javaclasses.mealorder.c.aggregate.po;
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
 import javaclasses.mealorder.PurchaseOrder;
-import javaclasses.mealorder.PurchaseOrderStatus;
 import javaclasses.mealorder.c.command.CancelPurchaseOrder;
 import javaclasses.mealorder.c.command.CreatePurchaseOrder;
 import javaclasses.mealorder.c.command.MarkPurchaseOrderAsDelivered;
@@ -89,6 +88,8 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
         assertEquals(purchaseOrderId, poCanceled.getId());
         assertEquals(PurchaseOrderCanceled.ReasonCase.CUSTOM_REASON, poCanceled.getReasonCase());
         assertEquals(cancelCmd.getCustomReason(), poCanceled.getCustomReason());
+        assertEquals(1, poCanceled.getOrderCount());
+
     }
 
     @Test
@@ -108,6 +109,7 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
         assertEquals(purchaseOrderId, poCanceled.getId());
         assertEquals(PurchaseOrderCanceled.ReasonCase.CUSTOM_REASON, poCanceled.getReasonCase());
         assertEquals("Reason not set.", poCanceled.getCustomReason());
+        assertEquals(1, poCanceled.getOrderCount());
     }
 
     @Test
@@ -127,6 +129,7 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
         assertEquals(purchaseOrderId, poCanceled.getId());
         assertEquals(PurchaseOrderCanceled.ReasonCase.INVALID, poCanceled.getReasonCase());
         assertEquals(cancelCmd.getInvalid(), poCanceled.getInvalid());
+        assertEquals(1, poCanceled.getOrderCount());
     }
 
     @Test

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/po/CancelPurchaseOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/po/CancelPurchaseOrderTest.java
@@ -64,7 +64,6 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
         dispatchCreatedCmd();
         final CancelPurchaseOrder cancelCmd = cancelPOWithCustomReasonInstance();
         dispatchCommand(aggregate, envelopeOf(cancelCmd));
-
         final PurchaseOrder state = aggregate.getState();
 
         assertEquals(purchaseOrderId, state.getId());
@@ -78,7 +77,6 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
         final CancelPurchaseOrder cancelCmd = cancelPOWithCustomReasonInstance();
         final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                     envelopeOf(cancelCmd));
-
         assertNotNull(aggregate.getId());
         assertEquals(1, messageList.size());
         assertEquals(PurchaseOrderCanceled.class, messageList.get(0)
@@ -89,7 +87,6 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
         assertEquals(PurchaseOrderCanceled.ReasonCase.CUSTOM_REASON, poCanceled.getReasonCase());
         assertEquals(cancelCmd.getCustomReason(), poCanceled.getCustomReason());
         assertEquals(1, poCanceled.getOrderCount());
-
     }
 
     @Test
@@ -155,5 +152,4 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
         final MarkPurchaseOrderAsDelivered markPOAsDelivered = markPurchaseOrderAsDeliveredInstance();
         dispatchCommand(aggregate, envelopeOf(markPOAsDelivered));
     }
-
 }

--- a/model/src/main/proto/javaclasses/mealorder/c/events.proto
+++ b/model/src/main/proto/javaclasses/mealorder/c/events.proto
@@ -310,4 +310,7 @@ message PurchaseOrderCanceled {
         bool invalid = 4;
         string custom_reason = 5;
     }
+
+    // The collection of orders to cancel.
+    repeated Order order = 6;
 }


### PR DESCRIPTION
In this small PR collection of `Order` has been added to `PurchaseOrderCanceled` event. This collection is needed to react on this event in `OrderAggregate` and apply `OrderProcessed` event to specified order instances.  