### PR TITLE
Proto definition refactor.

### DIFF
--- a/api-java/src/main/java/javaclasses/mealorder/c/aggregate/OrderAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/aggregate/OrderAggregate.java
@@ -112,7 +112,7 @@ public class OrderAggregate extends Aggregate<OrderId,
 
         final List<Menu> menus = vendorAggregate
                 .getState()
-                .getMenusList();
+                .getMenuList();
 
         final java.util.Optional<Menu> menu = menus.stream()
                                                    .filter(m -> cmd.getMenuId()
@@ -172,7 +172,7 @@ public class OrderAggregate extends Aggregate<OrderId,
             throwCannotRemoveDishFromNotActiveOrder(cmd, getState().getStatus());
         }
 
-        List<Dish> dishesList = getState().getDishesList();
+        List<Dish> dishesList = getState().getDishList();
 
         java.util.Optional<Dish> dish = dishesList.stream()
                                                   .filter(d -> d.getId()
@@ -212,7 +212,7 @@ public class OrderAggregate extends Aggregate<OrderId,
     void orderCreated(OrderCreated event) {
 
         if (getBuilder().getStatus() == ORDER_CANCELED) {
-            getBuilder().clearDishes();
+            getBuilder().clearDish();
         }
 
         getBuilder().setId(event.getOrderId())
@@ -222,18 +222,18 @@ public class OrderAggregate extends Aggregate<OrderId,
 
     @Apply
     void dishAddedToOrder(DishAddedToOrder event) {
-        getBuilder().addDishes(event.getDish())
+        getBuilder().addDish(event.getDish())
                     .build();
     }
 
     @Apply
     void dishRemovedFromOrder(DishRemovedFromOrder event) {
-        for (int i = 0; i < getBuilder().getDishes()
+        for (int i = 0; i < getBuilder().getDish()
                                         .size(); i++) {
             if (event.getDish()
-                     .equals(getBuilder().getDishes()
+                     .equals(getBuilder().getDish()
                                          .get(i))) {
-                getBuilder().removeDishes(i)
+                getBuilder().removeDish(i)
                             .build();
                 return;
             }

--- a/api-java/src/main/java/javaclasses/mealorder/c/aggregate/PurchaseOrderAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/aggregate/PurchaseOrderAggregate.java
@@ -104,14 +104,14 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
         Triplet result;
         final PurchaseOrderCreated poCreatedEvent = createPOCreatedEvent(cmd);
 
-        final List<Order> invalidOrders = findInvalidOrders(cmd.getOrdersList());
+        final List<Order> invalidOrders = findInvalidOrders(cmd.getOrderList());
 
         if (invalidOrders.isEmpty()) {
             final PurchaseOrderValidationPassed passedEvent = createPOValidationPassedEvent(cmd);
             final PurchaseOrder purchaseOrder = PurchaseOrder.newBuilder()
                                                              .setId(cmd.getId())
                                                              .setStatus(VALID)
-                                                             .addAllOrders(cmd.getOrdersList())
+                                                             .addAllOrder(cmd.getOrderList())
                                                              .build();
 
             final EmailAddress senderEmail = cmd.getWhoCreates()
@@ -174,7 +174,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
         if (!isAllowedToCancel()) {
             throwCannotCancelDeliveredPurchaseOrder(cmd);
         }
-        return createPOCanceledEvent(cmd, getState().getOrdersList());
+        return createPOCanceledEvent(cmd, getState().getOrderList());
     }
 
     /*
@@ -184,7 +184,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
     @Apply
     void purchaseOrderCreated(PurchaseOrderCreated event) {
         getBuilder().setId(event.getId())
-                    .addAllOrders(event.getOrdersList())
+                    .addAllOrder(event.getOrderList())
                     .setStatus(CREATED);
 
     }
@@ -242,7 +242,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
                                    .setId(cmd.getId())
                                    .setWhoCreated(cmd.getWhoCreates())
                                    .setWhenCreated(getCurrentTime())
-                                   .addAllOrders(cmd.getOrdersList())
+                                   .addAllOrder(cmd.getOrderList())
                                    .build();
     }
 
@@ -251,7 +251,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
             List<Order> invalidOrders) {
         return PurchaseOrderValidationFailed.newBuilder()
                                             .setId(cmd.getId())
-                                            .addAllFailureOrders(invalidOrders)
+                                            .addAllFailureOrder(invalidOrders)
                                             .setWhenFailed(getCurrentTime())
                                             .build();
     }

--- a/api-java/src/main/java/javaclasses/mealorder/c/aggregate/PurchaseOrderValidator.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/aggregate/PurchaseOrderValidator.java
@@ -62,7 +62,7 @@ public class PurchaseOrderValidator {
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final VendorId purchaseOrderVendorId = purchaseOrderId.getVendorId();
         final LocalDate poDate = purchaseOrderId.getPoDate();
-        final List<Order> ordersList = cmd.getOrdersList();
+        final List<Order> ordersList = cmd.getOrderList();
 
         for (final Order order : ordersList) {
             if (!(checkOrderIsActive(order) && checkOrderingDatesMatch(order, poDate))) {
@@ -93,7 +93,7 @@ public class PurchaseOrderValidator {
     }
 
     private static boolean isOrderValid(Order order) {
-        final HashMultiset<Dish> dishes = HashMultiset.create(order.getDishesList());
+        final HashMultiset<Dish> dishes = HashMultiset.create(order.getDishList());
         for (final Multiset.Entry<Dish> entry : dishes.entrySet()) {
             if (entry.getCount() > MAX_SINGLE_DISH_COUNT) {
                 return false;
@@ -109,7 +109,7 @@ public class PurchaseOrderValidator {
     }
 
     private static boolean checkOrderNotEmpty(Order order) {
-        return order.getDishesCount() != 0;
+        return order.getDishCount() != 0;
 
     }
 

--- a/api-java/src/main/java/javaclasses/mealorder/c/aggregate/VendorAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/aggregate/VendorAggregate.java
@@ -85,7 +85,7 @@ public class VendorAggregate extends Aggregate<VendorId, Vendor, VendorVBuilder>
                                                    .setWhoAdded(cmd.getUserId())
                                                    .setVendorName(vendorName)
                                                    .setEmail(cmd.getEmail())
-                                                   .addAllPhoneNumbers(cmd.getPhoneNumbersList())
+                                                   .addAllPhoneNumber(cmd.getPhoneNumberList())
                                                    .setPoDailyDeadline(
                                                            cmd.getPoDailyDeadline())
                                                    .build();
@@ -111,7 +111,7 @@ public class VendorAggregate extends Aggregate<VendorId, Vendor, VendorVBuilder>
                                                       .setMenuId(cmd.getMenuId())
                                                       .setWhoImported(cmd.getUserId())
                                                       .setWhenImported(getCurrentTime())
-                                                      .addAllDishes(cmd.getDishesList())
+                                                      .addAllDish(cmd.getDishList())
                                                       .build();
         return menuImported;
     }
@@ -143,7 +143,7 @@ public class VendorAggregate extends Aggregate<VendorId, Vendor, VendorVBuilder>
                     .setVendorName(event.getVendorName())
                     .setEmail(event.getEmail())
                     .setPoDailyDeadline(event.getPoDailyDeadline())
-                    .addAllPhoneNumbers(event.getPhoneNumbersList());
+                    .addAllPhoneNumber(event.getPhoneNumberList());
     }
 
     @Apply
@@ -155,22 +155,22 @@ public class VendorAggregate extends Aggregate<VendorId, Vendor, VendorVBuilder>
                                    .getNewEmail())
                     .setPoDailyDeadline(event.getVendorChange()
                                              .getNewPoDailyDeadline())
-                    .addAllPhoneNumbers(event.getVendorChange()
-                                             .getNewPhoneNumbersList());
+                    .addAllPhoneNumber(event.getVendorChange()
+                                             .getNewPhoneNumberList());
     }
 
     @Apply
     void menuImported(MenuImported event) {
 
-        getBuilder().addMenus(Menu.newBuilder()
+        getBuilder().addMenu(Menu.newBuilder()
                                   .setId(event.getMenuId())
-                                  .addAllDishes(event.getDishesList())
+                                  .addAllDish(event.getDishList())
                                   .build());
     }
 
     @Apply
     void dateRangeForMenuSet(DateRangeForMenuSet event) {
-        final List<Menu> menus = getBuilder().getMenus();
+        final List<Menu> menus = getBuilder().getMenu();
         final int index = IntStream.range(0, menus.size())
                                    .filter(i -> menus.get(i)
                                                      .getId()
@@ -178,7 +178,7 @@ public class VendorAggregate extends Aggregate<VendorId, Vendor, VendorVBuilder>
                                    .findFirst()
                                    .getAsInt();
         final Menu menu = menus.get(index);
-        getBuilder().setMenus(index, Menu.newBuilder(menu)
+        getBuilder().setMenu(index, Menu.newBuilder(menu)
                                          .setMenuDateRange(event.getMenuDateRange())
                                          .build());
     }

--- a/api-java/src/main/java/javaclasses/mealorder/c/aggregate/VendorValidator.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/aggregate/VendorValidator.java
@@ -71,7 +71,7 @@ class VendorValidator {
      * @param menuDateRange date range to check
      */
     static boolean isThereMenuForThisDateRange(Vendor vendor, MenuDateRange menuDateRange) {
-        final List<Menu> menus = vendor.getMenusList();
+        final List<Menu> menus = vendor.getMenuList();
         return menus.stream()
                     .anyMatch(m -> areRangesOverlapping(menuDateRange, m.getMenuDateRange()));
     }

--- a/api-java/src/main/java/javaclasses/mealorder/c/repository/OrderRepository.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/repository/OrderRepository.java
@@ -47,7 +47,7 @@ public class OrderRepository extends AggregateRepository<OrderId, OrderAggregate
             if (message instanceof PurchaseOrderCreated) {
                 final PurchaseOrderCreated purchaseOrderCreated = (PurchaseOrderCreated) message;
                 Set<OrderId> orderIds = new HashSet<>();
-                for (Order order : purchaseOrderCreated.getOrdersList()) {
+                for (Order order : purchaseOrderCreated.getOrderList()) {
                     if (find(order.getId()).isPresent()) {
                         orderIds.add(order.getId());
                     }

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/order/AddDishToOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/order/AddDishToOrderTest.java
@@ -113,7 +113,7 @@ public class AddDishToOrderTest extends OrderCommandTest {
 
         assertEquals(ORDER_ACTIVE, order.getStatus());
         assertEquals(addDishToOrder.getOrderId(), order.getId());
-        assertEquals(addDishToOrder.getDish(), order.getDishes(0));
+        assertEquals(addDishToOrder.getDish(), order.getDish(0));
     }
 
     @Test

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/order/RemoveDishFromOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/order/RemoveDishFromOrderTest.java
@@ -123,7 +123,7 @@ public class RemoveDishFromOrderTest extends OrderCommandTest<CreateOrder> {
 
         assertEquals(ORDER_ACTIVE, order.getStatus());
         assertEquals(addDishToOrder.getOrderId(), order.getId());
-        assertEquals(0, order.getDishesCount());
+        assertEquals(0, order.getDishCount());
     }
 
     @Test

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/po/CreatePurchaseOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/po/CreatePurchaseOrderTest.java
@@ -70,8 +70,8 @@ public class CreatePurchaseOrderTest extends PurchaseOrderCommandTest<CreatePurc
 
         final PurchaseOrder state = aggregate.getState();
         assertEquals(createPurchaseOrder.getId(), state.getId());
-        assertEquals(1, state.getOrdersCount());
-        assertEquals(ORDER, state.getOrdersList()
+        assertEquals(1, state.getOrderCount());
+        assertEquals(ORDER, state.getOrderList()
                                  .get(0));
         assertEquals(SENT, state.getStatus());
     }
@@ -102,8 +102,8 @@ public class CreatePurchaseOrderTest extends PurchaseOrderCommandTest<CreatePurc
         assertEquals(purchaseOrderId, purchaseOrderSent.getPurchaseOrder()
                                                        .getId());
         assertEquals(purchaseOrderSent.getPurchaseOrder()
-                                      .getOrdersList(), aggregate.getState()
-                                                                 .getOrdersList());
+                                      .getOrderList(), aggregate.getState()
+                                                                 .getOrderList());
     }
 
     @Test
@@ -125,8 +125,7 @@ public class CreatePurchaseOrderTest extends PurchaseOrderCommandTest<CreatePurc
 
         assertEquals(purchaseOrderId, purchaseOrderCreated.getId());
         assertEquals(purchaseOrderId, purchaseOrderValidationFailed.getId());
-        assertEquals(1, purchaseOrderValidationFailed.getFailureOrdersCount());
-        assertEquals(1, purchaseOrderValidationFailed.getFailureOrdersCount());
+        assertEquals(1, purchaseOrderValidationFailed.getFailureOrderCount());
     }
 
     @Nested

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/vendor/AddVendorTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/vendor/AddVendorTest.java
@@ -82,7 +82,7 @@ public class AddVendorTest extends VendorCommandTest<AddVendor> {
         assertEquals(EMAIL, vendorAdded.getEmail());
         assertEquals(PO_DAILY_DEADLINE, vendorAdded.getPoDailyDeadline());
 
-        final List<PhoneNumber> phones = vendorAdded.getPhoneNumbersList();
+        final List<PhoneNumber> phones = vendorAdded.getPhoneNumberList();
         assertEquals(PHONE_NUMBER1, phones.get(0));
         assertEquals(PHONE_NUMBER2, phones.get(1));
 

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/vendor/ImportMenuTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/vendor/ImportMenuTest.java
@@ -76,7 +76,7 @@ public class ImportMenuTest extends VendorCommandTest<AddVendor> {
         assertEquals(MENU_ID, menuImported.getMenuId());
         assertEquals(USER_ID, menuImported.getWhoImported());
 
-        final List<Dish> dishes = menuImported.getDishesList();
+        final List<Dish> dishes = menuImported.getDishList();
         assertEquals(DISH1, dishes.get(0));
         assertEquals(DISH2, dishes.get(1));
     }

--- a/api-java/src/test/java/javaclasses/mealorder/c/aggregate/vendor/SetDateRangeForMenuTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/aggregate/vendor/SetDateRangeForMenuTest.java
@@ -102,7 +102,7 @@ public class SetDateRangeForMenuTest extends VendorCommandTest<AddVendor> {
         final Vendor state = aggregate.getState();
         assertEquals(state.getId(), setDateRangeForMenu.getVendorId());
 
-        final Menu menu = state.getMenusList()
+        final Menu menu = state.getMenuList()
                                .stream()
                                .filter(m -> m.getId()
                                              .equals(setDateRangeForMenu.getMenuId()))

--- a/model/src/main/proto/javaclasses/mealorder/c/commands.proto
+++ b/model/src/main/proto/javaclasses/mealorder/c/commands.proto
@@ -56,7 +56,7 @@ message AddVendor {
     spine.net.EmailAddress email = 4;
 
     // Phone numbers of a vendor.
-    repeated PhoneNumber phone_numbers = 5;
+    repeated PhoneNumber phone_number = 5;
 
     // Time when orders for this vendor are closed for editing.
     // Purchase orders for a vendor will be created exactly at this time.
@@ -91,7 +91,7 @@ message ImportMenu {
     UserId user_id = 3;
 
     // The collection of dishes.
-    repeated Dish dishes = 4;
+    repeated Dish dish = 4;
 }
 
 // Sets a menu date range.
@@ -176,7 +176,7 @@ message CreatePurchaseOrder {
     PurchaseOrderId id = 1;
 
     // The collection of all orders for this day for the specified vendor.
-    repeated Order orders = 2;
+    repeated Order order = 2;
 
     // The identifier of the user who creates a purchase order.
     UserId who_creates = 3;

--- a/model/src/main/proto/javaclasses/mealorder/c/events.proto
+++ b/model/src/main/proto/javaclasses/mealorder/c/events.proto
@@ -57,7 +57,7 @@ message VendorAdded {
     spine.net.EmailAddress email = 5;
 
     // Phone numbers of a vendor.
-    repeated PhoneNumber phone_numbers = 6;
+    repeated PhoneNumber phone_number = 6;
 
     // Time to which all orders to this vendor must be made.
     spine.time.LocalTime po_daily_deadline = 7;
@@ -100,7 +100,7 @@ message MenuImported {
     google.protobuf.Timestamp when_imported = 4;
 
     // The collection of menu dishes.
-    repeated Dish dishes = 5;
+    repeated Dish dish = 5;
 }
 
 // The event reflecting a menu active date range set.
@@ -206,7 +206,7 @@ message PurchaseOrderCreated {
     UserId who_created = 3;
 
     // The collection of all orders for this day.
-    repeated Order orders = 4;
+    repeated Order order = 4;
 }
 
 // The event signalizing about the successful delivering of a purchase order.
@@ -254,7 +254,7 @@ message PurchaseOrderValidationFailed {
     PurchaseOrderId id = 1;
 
     // The collection of orders that caused a failure of validation.
-    repeated Order failure_orders = 2;
+    repeated Order failure_order = 2;
 
     // Validation failed at this time.
     google.protobuf.Timestamp when_failed = 3;

--- a/model/src/main/proto/javaclasses/mealorder/model.proto
+++ b/model/src/main/proto/javaclasses/mealorder/model.proto
@@ -68,7 +68,7 @@ message Menu {
     MenuDateRange menu_date_range = 2;
 
     // The collection of dishes.
-    repeated Dish dishes = 3;
+    repeated Dish dish = 3;
 }
 
 // The model representing the `Order` aggregate.
@@ -90,7 +90,7 @@ message Order {
     OrderId id = 1;
 
     // The collection of dishes.
-    repeated Dish dishes = 2;
+    repeated Dish dish = 2;
 
     // The status of an order.
     OrderStatus status = 3;
@@ -130,7 +130,7 @@ message PurchaseOrder {
     PurchaseOrderId id = 1;
 
     // The collection of orders.
-    repeated Order orders = 2;
+    repeated Order order = 2;
 
     // The status of a purchase order.
     PurchaseOrderStatus status = 3;
@@ -150,7 +150,7 @@ message Vendor {
     spine.net.EmailAddress email = 3;
 
     // The phone numbers of a vendor.
-    repeated PhoneNumber phone_numbers = 4;
+    repeated PhoneNumber phone_number = 4;
 
     // Daily deadline time.
     //
@@ -159,5 +159,5 @@ message Vendor {
     spine.time.LocalTime po_daily_deadline = 5;
 
     // The collection of menus.
-    repeated Menu menus = 6;
+    repeated Menu menu = 6;
 }

--- a/model/src/main/proto/javaclasses/mealorder/q/projections.proto
+++ b/model/src/main/proto/javaclasses/mealorder/q/projections.proto
@@ -63,7 +63,7 @@ message MenuListView {
     MenuListId list_id = 1;
 
     // The collection of menus.
-    repeated MenuItem menus = 2;
+    repeated MenuItem menu = 2;
 }
 
 // The projection state of the menu calendar.
@@ -78,7 +78,7 @@ message MenuListView {
 message MenuCalendarView {
 
     // The collection of calendar items (dates).
-    repeated MenuCalendarItem calendar_items = 1;
+    repeated MenuCalendarItem calendar_item = 1;
 }
 
 // The projection state of an order list.
@@ -100,7 +100,7 @@ message OrderListView {
     OrderListId list_id = 1;
 
     // The collection of user's orders.
-    repeated OrderItem orders = 2;
+    repeated OrderItem order = 2;
 }
 
 // **** Projections for UI role Admin. ****
@@ -114,7 +114,7 @@ message OrderListView {
 message VendorListView {
 
     // The collection of all vendors.
-    repeated VendorItem vendors = 1;
+    repeated VendorItem vendor = 1;
 }
 
 // The projection state of the full menu list.
@@ -129,7 +129,7 @@ message VendorListView {
 message FullMenuListView {
 
     // The collection of all menus.
-    repeated FullMenuItem menus = 1;
+    repeated FullMenuItem menu = 1;
 }
 
 // The projection state of the purchase order list.
@@ -149,7 +149,7 @@ message FullMenuListView {
 message PurchaseOrderListView {
 
     // The collection of all purchase orders.
-    repeated PurchaseOrderItem purchase_orders = 1;
+    repeated PurchaseOrderItem purchase_order = 1;
 }
 
 // The projection state of a purchase order details view
@@ -173,7 +173,7 @@ message PurchaseOrderDetailsByDishView {
     PurchaseOrderStatus purchase_order_status = 2;
 
     // The collection of dishes.
-    repeated DishItem dishes = 3;
+    repeated DishItem dish = 3;
 }
 
 // The projection state of a purchase order details view
@@ -200,7 +200,7 @@ message PurchaseOrderDetailsByUserView {
     PurchaseOrderStatus purchase_order_status = 2;
 
     // The collection of orders.
-    repeated UserOrderDetails orders = 3;
+    repeated UserOrderDetails order = 3;
 }
 
 // The projection state of a monthly spendings report view.
@@ -222,5 +222,5 @@ message MonthlySpendingsReportView {
     MonthlySpendingsReportId report_id = 1;
 
     // The collection of users spendings for the specified month.
-    repeated UserSpendings user_spendinds = 2;
+    repeated UserSpendings user_spending = 2;
 }

--- a/model/src/main/proto/javaclasses/mealorder/q/values.proto
+++ b/model/src/main/proto/javaclasses/mealorder/q/values.proto
@@ -48,7 +48,7 @@ message MenuItem {
     VendorName vendor_name = 1;
 
     // The collection of dishes.
-    repeated DishItem dishes = 2;
+    repeated DishItem dish = 2;
 }
 
 // The single dish item of a menu.
@@ -102,7 +102,7 @@ message OrderItem {
     OrderId id = 1;
 
     // The collection of ordered dishes.
-    repeated DishItem dishes = 2;
+    repeated DishItem dish = 2;
 
     // Indicates an order is processed or not.
     bool is_processed = 3;
@@ -122,7 +122,7 @@ message VendorItem {
     spine.net.EmailAddress email = 3;
 
     // Phone numbers of the vendor.
-    repeated PhoneNumber phone_numbers = 4;
+    repeated PhoneNumber phone_number = 4;
 
     // Daily purchase order creation deadline time.
     spine.time.LocalTime po_daily_deadline = 5;
@@ -139,7 +139,7 @@ message FullMenuItem {
     MenuDateRange menu_date_range = 2;
 
     // The collection of dishes.
-    repeated DishItem dishes = 3;
+    repeated DishItem dish = 3;
 }
 
 // The item of the purchase order list.
@@ -166,7 +166,7 @@ message UserOrderDetails {
     UserId id = 1;
 
     // The collection of dishes.
-    repeated DishItem dishes = 2;
+    repeated DishItem dish = 2;
 
     // An order validation status.
     bool is_valid = 3;

--- a/model/src/main/proto/javaclasses/mealorder/values.proto
+++ b/model/src/main/proto/javaclasses/mealorder/values.proto
@@ -74,7 +74,7 @@ message VendorChange {
     spine.net.EmailAddress previous_email = 2;
 
     // Phone numbers that are changing.
-    repeated PhoneNumber previous_phone_numbers = 3;
+    repeated PhoneNumber previous_phone_number = 3;
 
     // Daily deadline time that's changing.
     spine.time.LocalTime previous_po_daily_deadline = 4;
@@ -86,7 +86,7 @@ message VendorChange {
     spine.net.EmailAddress new_email = 6;
 
     // New phone numbers.
-    repeated PhoneNumber new_phone_numbers = 7;
+    repeated PhoneNumber new_phone_number = 7;
 
     // The new daily deadline time.
     spine.time.LocalTime new_po_daily_deadline = 8;

--- a/testutil-api/src/main/java/javaclasses/mealorder/testdata/TestPurchaseOrderCommandFactory.java
+++ b/testutil-api/src/main/java/javaclasses/mealorder/testdata/TestPurchaseOrderCommandFactory.java
@@ -59,7 +59,7 @@ public class TestPurchaseOrderCommandFactory {
         final CreatePurchaseOrder result = CreatePurchaseOrder.newBuilder()
                                                               .setId(PURCHASE_ORDER_ID)
                                                               .setWhoCreates(USER_ID)
-                                                              .addOrders(ORDER)
+                                                              .addOrder(ORDER)
                                                               .build();
         return result;
     }
@@ -89,9 +89,9 @@ public class TestPurchaseOrderCommandFactory {
      */
     public static CreatePurchaseOrder createPurchaseOrderWithNotActiveOrdersInstance() {
         final CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
-        final Order order = validCmd.getOrders(0);
+        final Order order = validCmd.getOrder(0);
         return CreatePurchaseOrder.newBuilder(validCmd)
-                                  .addOrders(Order.newBuilder(order)
+                                  .addOrder(Order.newBuilder(order)
                                                   .setStatus(ORDER_CANCELED))
                                   .build();
     }
@@ -104,9 +104,9 @@ public class TestPurchaseOrderCommandFactory {
      */
     public static CreatePurchaseOrder createPurchaseOrderWithEmptyOrdersInstance() {
         final CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
-        final Order order = validCmd.getOrders(0);
+        final Order order = validCmd.getOrder(0);
         return CreatePurchaseOrder.newBuilder(validCmd)
-                                  .addOrders(Order.newBuilder()
+                                  .addOrder(Order.newBuilder()
                                                   .setStatus(order.getStatus())
                                                   .setId(order.getId())
                                                   .build())
@@ -121,9 +121,9 @@ public class TestPurchaseOrderCommandFactory {
      */
     public static CreatePurchaseOrder createPurchaseOrderWithDatesMismatchOrdersInstance() {
         final CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
-        final Order order = validCmd.getOrders(0);
+        final Order order = validCmd.getOrder(0);
         return CreatePurchaseOrder.newBuilder(validCmd)
-                                  .addOrders(Order.newBuilder(order)
+                                  .addOrder(Order.newBuilder(order)
                                                   .setId(OrderId.newBuilder(order.getId())
                                                                 .setOrderDate(
                                                                         LocalDate.getDefaultInstance()))
@@ -140,15 +140,15 @@ public class TestPurchaseOrderCommandFactory {
      */
     public static CreatePurchaseOrder createPurchaseOrderWithInvalidOrdersInstance() {
         CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
-        final Order order = validCmd.getOrders(0);
-        final Dish dish = order.getDishes(0);
+        final Order order = validCmd.getOrder(0);
+        final Dish dish = order.getDish(0);
         List<Dish> dishes = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
             dishes.add(dish);
         }
         return CreatePurchaseOrder.newBuilder(validCmd)
-                                  .addOrders(Order.newBuilder(order)
-                                                  .addAllDishes(dishes)
+                                  .addOrder(Order.newBuilder(order)
+                                                  .addAllDish(dishes)
                                                   .build())
                                   .build();
     }

--- a/testutil-api/src/main/java/javaclasses/mealorder/testdata/TestValues.java
+++ b/testutil-api/src/main/java/javaclasses/mealorder/testdata/TestValues.java
@@ -90,16 +90,16 @@ public class TestValues {
     public static final VendorChange VENDOR_CHANGE = VendorChange.newBuilder()
                                                                  .setPreviousVendorName(VENDOR_NAME)
                                                                  .setPreviousEmail(EMAIL)
-                                                                 .addPreviousPhoneNumbers(
+                                                                 .addPreviousPhoneNumber(
                                                                          PHONE_NUMBER1)
-                                                                 .addPreviousPhoneNumbers(
+                                                                 .addPreviousPhoneNumber(
                                                                          PHONE_NUMBER2)
                                                                  .setPreviousPoDailyDeadline(
                                                                          PO_DAILY_DEADLINE)
                                                                  .setNewVendorName(NEW_VENDOR_NAME)
                                                                  .setNewEmail(EMAIL)
-                                                                 .addNewPhoneNumbers(PHONE_NUMBER1)
-                                                                 .addNewPhoneNumbers(PHONE_NUMBER2)
+                                                                 .addNewPhoneNumber(PHONE_NUMBER1)
+                                                                 .addNewPhoneNumber(PHONE_NUMBER2)
                                                                  .setPreviousPoDailyDeadline(
                                                                          PO_DAILY_DEADLINE)
                                                                  .build();
@@ -209,7 +209,7 @@ public class TestValues {
 
     public static final Order ORDER = Order.newBuilder()
                                            .setId(ORDER_ID)
-                                           .addDishes(DISH1)
+                                           .addDish(DISH1)
                                            .setStatus(ORDER_ACTIVE)
                                            .build();
 }

--- a/testutil-api/src/main/java/javaclasses/mealorder/testdata/TestVendorCommandFactory.java
+++ b/testutil-api/src/main/java/javaclasses/mealorder/testdata/TestVendorCommandFactory.java
@@ -78,8 +78,8 @@ public class TestVendorCommandFactory {
                                           .setVendorName(vendorName)
                                           .setEmail(email)
                                           .setPoDailyDeadline(poDailyDeadline)
-                                          .addPhoneNumbers(phones[0])
-                                          .addPhoneNumbers(phones[1])
+                                          .addPhoneNumber(phones[0])
+                                          .addPhoneNumber(phones[1])
                                           .build();
         return result;
     }
@@ -139,8 +139,8 @@ public class TestVendorCommandFactory {
                                             .setVendorId(vendorId)
                                             .setUserId(userId)
                                             .setMenuId(menuId)
-                                            .addDishes(dishes[0])
-                                            .addDishes(dishes[1])
+                                            .addDish(dishes[0])
+                                            .addDish(dishes[1])
                                             .build();
         return result;
     }


### PR DESCRIPTION
In this small PR proto definition for repeated fields were changed.
For example
Praviously : 
`// The collection of dishes.
    repeated Dish dishes = 3;`
Now: 
`// The collection of dishes.
    repeated Dish dish = 3;`
This change was needed to perform because proto generated classes had plural setters names.