### PR TITLE
Vendor aggregate refactor

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,7 +12,10 @@ coverage:
   - testutil-api/src/main/java/javaclasses/mealorder/testdata/*
 
   status:
-    patch: false
+      patch:
+       default:
+          enabled: yes             # must be yes|true to enable this status
+          target: 95%              # specify the target "X%" coverage to hit
 
 comment:
   layout: "header, diff, changes, uncovered"

--- a/api-java/src/main/java/javaclasses/mealorder/LocalDateComparator.java
+++ b/api-java/src/main/java/javaclasses/mealorder/LocalDateComparator.java
@@ -24,18 +24,22 @@ import io.spine.time.LocalDate;
 
 import java.util.Comparator;
 
+import static java.lang.String.format;
+
 /**
  * @author Yurii Haidamaka
  */
 public class LocalDateComparator implements Comparator<LocalDate> {
 
     /**
-     * Compares its two arguments for order.  Returns a negative integer,
-     * zero, or a positive integer as the first argument is less than, equal
-     * to, or greater than the second.
+     * Compares its two arguments for order.
      *
-     * @param o1 the first LocalDate object to be compared.
-     * @param o2 the second LocalDate object to be compared.
+     * <p>Returns a negative integer,zero, or a positive integer
+     * as the first argument is less than, equal to, or greater
+     * than the second.
+     *
+     * @param o1 the first LocalDate object to be compared
+     * @param o2 the second LocalDate object to be compared
      * @return a negative integer, zero, or a positive integer as the
      * first date is less than, equal to, or greater than the
      * second.
@@ -43,9 +47,9 @@ public class LocalDateComparator implements Comparator<LocalDate> {
     @Override
     public int compare(LocalDate o1, LocalDate o2) {
         final String o1String =
-                String.format("%04d%02d%02d", o1.getYear(), o1.getMonth().getNumber(), o1.getDay());
+                format("%04d%02d%02d", o1.getYear(), o1.getMonth().getNumber(), o1.getDay());
         final String o2String =
-                String.format("%04d%02d%02d", o2.getYear(), o2.getMonth().getNumber(), o2.getDay());
+                format("%04d%02d%02d", o2.getYear(), o2.getMonth().getNumber(), o2.getDay());
 
         return o1String.compareTo(o2String);
     }

--- a/api-java/src/main/java/javaclasses/mealorder/LocalDateComparator.java
+++ b/api-java/src/main/java/javaclasses/mealorder/LocalDateComparator.java
@@ -32,9 +32,9 @@ import static java.lang.String.format;
 public class LocalDateComparator implements Comparator<LocalDate> {
 
     /**
-     * Compares its two arguments for order.
+     * Compares two LocalDate arguments for order.
      *
-     * <p>Returns a negative integer,zero, or a positive integer
+     * <p> Returns a negative integer, zero, or a positive integer
      * as the first argument is less than, equal to, or greater
      * than the second.
      *

--- a/api-java/src/main/java/javaclasses/mealorder/c/package-info.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/package-info.java
@@ -20,7 +20,7 @@
 
 /**
  * This package contains implementation for classes which provides
- * methods to process aggregates and projection.
+ * methods to process aggregates and projections.
  */
 @ParametersAreNonnullByDefault
 package javaclasses.mealorder.c;

--- a/api-java/src/main/java/javaclasses/mealorder/c/vendor/VendorAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/vendor/VendorAggregate.java
@@ -56,6 +56,8 @@ import static javaclasses.mealorder.c.vendor.Vendors.isValidDateRange;
  *
  * @author Yurii Haidamaka
  */
+@SuppressWarnings("OverlyCoupledClass") /* As each method needs dependencies  necessary to perform
+                                           execution that class also overly coupled.*/
 public class VendorAggregate extends Aggregate<VendorId, Vendor, VendorVBuilder> {
 
     public VendorAggregate(VendorId id) {

--- a/api-java/src/main/java/javaclasses/mealorder/c/vendor/VendorAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/vendor/VendorAggregateRejections.java
@@ -33,40 +33,42 @@ import static io.spine.time.Time.getCurrentTime;
  *
  * @author Yurii Haidamaka
  */
-public class VendorAggregateRejections {
+class VendorAggregateRejections {
 
     /** Prevents instantiation of this utility class. */
     private VendorAggregateRejections() {
     }
 
     /**
-     * Constructs and returns the {@link VendorAlreadyExists} rejection
+     * Constructs and throws the {@link VendorAlreadyExists} rejection
      * according to the passed parameters.
      *
      * @param cmd the {@code AddVendor} command which thrown the rejection
-     * @return VendorAlreadyExists the rejection to return
+     * @throws VendorAlreadyExists the rejection to throw
      */
-    public static VendorAlreadyExists vendorAlreadyExists(AddVendor cmd) {
+    static VendorAlreadyExists vendorAlreadyExists(AddVendor cmd) throws
+                                                                  VendorAlreadyExists {
         checkNotNull(cmd);
         final VendorAlreadyExists vendorAlreadyExists = new VendorAlreadyExists(cmd.getVendorId(),
                                                                                 cmd.getVendorName(),
                                                                                 getCurrentTime());
-        return vendorAlreadyExists;
+        throw vendorAlreadyExists;
     }
 
     /**
-     * Constructs and returns the {@link CannotSetDateRange} rejection
+     * Constructs and throws the {@link CannotSetDateRange} rejection
      * according to the passed parameters.
      *
      * @param cmd the {@code SetDateRangeForMenu} command which thrown the rejection
-     * @return CannotSetDateRange the rejection to return
+     * @throws CannotSetDateRange the rejection to throw
      */
-    public static CannotSetDateRange cannotSetDateRange(SetDateRangeForMenu cmd) {
+    static CannotSetDateRange cannotSetDateRange(SetDateRangeForMenu cmd) throws
+                                                                          CannotSetDateRange {
         checkNotNull(cmd);
         final CannotSetDateRange cannotSetDateRange = new CannotSetDateRange(cmd.getVendorId(),
                                                                              cmd.getMenuId(),
                                                                              cmd.getMenuDateRange(),
                                                                              getCurrentTime());
-        return cannotSetDateRange;
+        throw cannotSetDateRange;
     }
 }

--- a/api-java/src/main/java/javaclasses/mealorder/c/vendor/Vendors.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/vendor/Vendors.java
@@ -20,7 +20,6 @@
 
 package javaclasses.mealorder.c.vendor;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.spine.time.LocalDate;
 import io.spine.time.MonthOfYear;
 import javaclasses.mealorder.LocalDateComparator;
@@ -38,7 +37,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Yurii Haidamaka
  */
-public class Vendors {
+class Vendors {
 
     /** Prevents instantiation of this utility class. */
     private Vendors() {
@@ -50,7 +49,7 @@ public class Vendors {
      *
      * @param menuDateRange date range to check
      */
-    public static boolean isValidDateRange(MenuDateRange menuDateRange) {
+    static boolean isValidDateRange(MenuDateRange menuDateRange) {
         checkNotNull(menuDateRange);
 
         final LocalDate startDateRange = menuDateRange.getRangeStart();
@@ -80,11 +79,11 @@ public class Vendors {
      *
      * @param vendor aggregate vendor
      * @param range  date range to check
+     * @return boolean true if there is menu for this date range and false if not
      */
-    public static boolean isThereMenuForThisDateRange(Vendor vendor, MenuDateRange range) {
+    static boolean isThereMenuForThisDateRange(Vendor vendor, MenuDateRange range) {
         checkNotNull(vendor);
         checkNotNull(range);
-
         final List<Menu> menus = vendor.getMenuList();
         return menus.stream()
                     .anyMatch(m -> areRangesOverlapping(range, m.getMenuDateRange()));
@@ -97,7 +96,6 @@ public class Vendors {
      * @param range2 the date range
      * @return boolean true if the date ranges are overlapped and false otherwise
      */
-    @VisibleForTesting
     private static boolean areRangesOverlapping(MenuDateRange range1, MenuDateRange range2) {
         final LocalDate start = range1.getRangeStart();
         final LocalDate end = range1.getRangeEnd();

--- a/api-java/src/main/java/javaclasses/mealorder/c/vendor/Vendors.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/vendor/Vendors.java
@@ -65,10 +65,10 @@ class Vendors {
 
     private static LocalDate getCurrentDate() {
         final java.time.LocalDate currentDateJava = java.time.LocalDate.now();
+        final MonthOfYear currentMonthOfYear = MonthOfYear.valueOf(currentDateJava.getMonthValue());
         final LocalDate currentDate = LocalDate.newBuilder()
                                                .setYear(currentDateJava.getYear())
-                                               .setMonth(MonthOfYear.valueOf(
-                                                       currentDateJava.getMonthValue()))
+                                               .setMonth(currentMonthOfYear)
                                                .setDay(currentDateJava.getDayOfMonth())
                                                .build();
         return currentDate;

--- a/api-java/src/main/java/javaclasses/mealorder/c/vendor/package-info.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/vendor/package-info.java
@@ -20,9 +20,9 @@
 
 /**
  * This package contains implementation for classes which provides
- * methods to process OrderAggregate.
+ * methods to process {@code VendorAggregate}.
  */
 @ParametersAreNonnullByDefault
-package javaclasses.mealorder.c.order;
+package javaclasses.mealorder.c.vendor;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api-java/src/test/java/javaclasses/mealorder/c/BoundedContextsTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/BoundedContextsTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author Yurii Haidamaka
  */
-@DisplayName("BoundedContexts should")
+@DisplayName("`BoundedContexts` should")
 class BoundedContextsTest {
 
     @Test
@@ -51,15 +51,14 @@ class BoundedContextsTest {
     }
 
     @Test
-    @DisplayName("not create BoundedContext without a StorageFactory")
+    @DisplayName("not create `BoundedContext` without a `StorageFactory`")
     void notCreateBoundedContextWithoutStorageFactory() {
         assertThrows(NullPointerException.class, () -> createBoundedContext(Tests.nullRef()));
     }
 
     @Test
-    @DisplayName("create BoundedContext with the InMemoryStorageFactory")
+    @DisplayName("create `BoundedContext` with the `InMemoryStorageFactory`")
     void createBoundedContextWithInMemoryStorageFactory() {
-
         BoundedContext boundedContext = BoundedContexts.create();
 
         assertEquals(InMemoryStorageFactory.class, boundedContext.getStorageFactory()
@@ -67,9 +66,8 @@ class BoundedContextsTest {
     }
 
     @Test
-    @DisplayName("create BoundedContext with a given StorageFactory ")
+    @DisplayName("create `BoundedContext` with a given `StorageFactory` ")
     void createBoundedContextWithStorageFactory() {
-
         final StorageFactory inMemoryFactory =
                 InMemoryStorageFactory.newInstance(
                         BoundedContext.newName("MealOrderBoundedContext"), false);
@@ -80,9 +78,8 @@ class BoundedContextsTest {
     }
 
     @Test
-    @DisplayName("create BoundedContext with VendorRepository, OrderRepository and PurchaseOrderRepository")
+    @DisplayName("create `BoundedContext` with `VendorRepository`, `OrderRepository` and `PurchaseOrderRepository`")
     void createBoundedContextWithoutVendorRepository() {
-
         final StorageFactory inMemoryFactory =
                 InMemoryStorageFactory.newInstance(
                         BoundedContext.newName("MealOrderBoundedContext"), false);

--- a/api-java/src/test/java/javaclasses/mealorder/c/MealOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/MealOrderTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.mealorder.c;
+
+import com.google.common.base.Optional;
+import com.google.protobuf.GeneratedMessageV3;
+import io.spine.client.ActorRequestFactory;
+import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
+import io.spine.core.Command;
+import io.spine.grpc.MemoizingObserver;
+import io.spine.server.BoundedContext;
+import io.spine.server.commandbus.CommandBus;
+import io.spine.server.entity.Repository;
+import javaclasses.mealorder.PurchaseOrder;
+import javaclasses.mealorder.PurchaseOrderSender;
+import javaclasses.mealorder.ServiceFactory;
+import javaclasses.mealorder.c.po.PurchaseOrderAggregate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.protobuf.TypeConverter.toMessage;
+import static javaclasses.mealorder.PurchaseOrderStatus.DELIVERED;
+import static javaclasses.mealorder.testdata.TestOrderCommandFactory.addDishToOrderInstance;
+import static javaclasses.mealorder.testdata.TestOrderCommandFactory.createOrderInstance;
+import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderInstance;
+import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.markPurchaseOrderAsDeliveredInstance;
+import static javaclasses.mealorder.testdata.TestValues.PURCHASE_ORDER_ID;
+import static javaclasses.mealorder.testdata.TestVendorCommandFactory.addVendorInstance;
+import static javaclasses.mealorder.testdata.TestVendorCommandFactory.importMenuInstance;
+import static javaclasses.mealorder.testdata.TestVendorCommandFactory.setDateRangeForMenuInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("MealOrder Integration Test")
+class MealOrderTest {
+    private final ActorRequestFactory requestFactory =
+            TestActorRequestFactory.newInstance(getClass());
+
+    private final BoundedContext boundedContext = BoundedContexts.create();
+    private final CommandBus commandBus = boundedContext.getCommandBus();
+
+    private Command createCommand(GeneratedMessageV3 message) {
+        return getRequestFactory().command()
+                                  .create(toMessage(message));
+    }
+
+    @BeforeEach
+    public void setUp() {
+        final PurchaseOrderSender purchaseOrderSenderMock = mock(PurchaseOrderSender.class);
+        ServiceFactory.setPoSenderInstance(purchaseOrderSenderMock);
+    }
+
+    @Test
+    @DisplayName("Add vendor -> Import menu -> Set date range for menu ->" +
+            " Create order -> Add dish to order -> Create purchase order ->" +
+            " Mark purchase order as delivered ")
+    void firstFlow() {
+        final MemoizingObserver<Ack> observer = MemoizingObserver.newInstance();
+
+        final Command addVendor = createCommand(addVendorInstance());
+        commandBus.post(addVendor, observer);
+
+        final Command importMenu = createCommand(importMenuInstance());
+        commandBus.post(importMenu, observer);
+
+        final Command setDateRangeForMenu = createCommand(setDateRangeForMenuInstance());
+        commandBus.post(setDateRangeForMenu, observer);
+
+        final Command createOrderCommand = createCommand(createOrderInstance());
+        commandBus.post(createOrderCommand, observer);
+
+        final Command addDishToOrderCommand = createCommand(addDishToOrderInstance());
+        commandBus.post(addDishToOrderCommand, observer);
+
+        final Command createPOCommand = createCommand(createPurchaseOrderInstance());
+        commandBus.post(createPOCommand, observer);
+
+        final Command markAsDeliveredCommand = createCommand(
+                markPurchaseOrderAsDeliveredInstance());
+        commandBus.post(markAsDeliveredCommand, observer);
+
+        assertNull(observer.getError());
+
+        final Optional<Repository> purchaseOrderRepository = boundedContext.findRepository(
+                PurchaseOrder.class);
+
+        assertTrue(purchaseOrderRepository.isPresent());
+        Optional<PurchaseOrderAggregate> purchaseOrder = purchaseOrderRepository.get()
+                                                                                .find(PURCHASE_ORDER_ID);
+
+        assertTrue(purchaseOrder.isPresent());
+        assertEquals(DELIVERED, purchaseOrder.get()
+                                             .getState()
+                                             .getStatus());
+    }
+
+    private ActorRequestFactory getRequestFactory() {
+        return requestFactory;
+    }
+}

--- a/api-java/src/test/java/javaclasses/mealorder/c/vendor/AddVendorTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/vendor/AddVendorTest.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * @author Yurii Haidamaka
  */
-@DisplayName("AddVendor command should be interpreted by VendorAggregate and")
+@DisplayName("`AddVendor` command should be interpreted by `VendorAggregate` and")
 public class AddVendorTest extends VendorCommandTest<AddVendor> {
 
     @Override
@@ -63,7 +63,7 @@ public class AddVendorTest extends VendorCommandTest<AddVendor> {
     }
 
     @Test
-    @DisplayName("produce VendorAdded event")
+    @DisplayName("produce `VendorAdded` event")
     void produceEvent() {
         final AddVendor addVendorCmd = TestVendorCommandFactory.addVendorInstance();
 
@@ -102,7 +102,7 @@ public class AddVendorTest extends VendorCommandTest<AddVendor> {
     }
 
     @Test
-    @DisplayName("throw VendorAlreadyExists rejection upon " +
+    @DisplayName("throw `VendorAlreadyExists` rejection upon " +
             "an attempt to add a vendor with the same name")
     void notAddVendor() {
         final AddVendor addVendor = TestVendorCommandFactory.addVendorInstance();

--- a/api-java/src/test/java/javaclasses/mealorder/c/vendor/ImportMenuTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/vendor/ImportMenuTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * @author Yurii Haidamaka
  */
-@DisplayName("ImportMenu command should be interpreted by VendorAggregate and")
+@DisplayName("`ImportMenu` command should be interpreted by `VendorAggregate` and")
 public class ImportMenuTest extends VendorCommandTest<AddVendor> {
 
     @Override
@@ -55,7 +55,7 @@ public class ImportMenuTest extends VendorCommandTest<AddVendor> {
     }
 
     @Test
-    @DisplayName("produce MenuImported event")
+    @DisplayName("produce `MenuImported` event")
     void produceEvent() {
         final AddVendor addVendorCmd = TestVendorCommandFactory.addVendorInstance();
         dispatchCommand(aggregate, envelopeOf(addVendorCmd));

--- a/api-java/src/test/java/javaclasses/mealorder/c/vendor/SetDateRangeForMenuTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/vendor/SetDateRangeForMenuTest.java
@@ -54,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * @author Yurii Haidamaka
  */
-@DisplayName("SetDateRangeForMenu command should be interpreted by VendorAggregate and")
+@DisplayName("`SetDateRangeForMenu` command should be interpreted by `VendorAggregate` and")
 public class SetDateRangeForMenuTest extends VendorCommandTest<AddVendor> {
 
     @Override
@@ -64,7 +64,7 @@ public class SetDateRangeForMenuTest extends VendorCommandTest<AddVendor> {
     }
 
     @Test
-    @DisplayName("produce DateRangeForMenuSet event")
+    @DisplayName("produce `DateRangeForMenuSet` event")
     void produceEvent() {
         final ImportMenu importMenu = TestVendorCommandFactory.importMenuInstance();
         dispatchCommand(aggregate, envelopeOf(importMenu));
@@ -117,7 +117,7 @@ public class SetDateRangeForMenuTest extends VendorCommandTest<AddVendor> {
     }
 
     @Test
-    @DisplayName("produce CannotSetDateRange rejection if date range is not valid")
+    @DisplayName("produce `CannotSetDateRange` rejection if date range is not valid")
     void produceRejection() {
         final ImportMenu importMenu = TestVendorCommandFactory.importMenuInstance();
         dispatchCommand(aggregate, envelopeOf(importMenu));
@@ -142,7 +142,7 @@ public class SetDateRangeForMenuTest extends VendorCommandTest<AddVendor> {
     }
 
     @Test
-    @DisplayName("produce CannotSetDateRange rejection if the order date  is from the past")
+    @DisplayName("produce `CannotSetDateRange` rejection if the order date is from the past")
     void produceCannotSetDateRangeRejection() {
         final ImportMenu importMenu = TestVendorCommandFactory.importMenuInstance();
         dispatchCommand(aggregate, envelopeOf(importMenu));
@@ -165,7 +165,7 @@ public class SetDateRangeForMenuTest extends VendorCommandTest<AddVendor> {
     }
 
     @Test
-    @DisplayName("produce CannotSetDateRange rejection if vendor already has menu on this date range")
+    @DisplayName("produce `CannotSetDateRange` rejection if vendor already has menu on this date range")
     void produceRejectionIfMenuExists() {
         final ImportMenu importMenu = TestVendorCommandFactory.importMenuInstance();
         dispatchCommand(aggregate, envelopeOf(importMenu));

--- a/api-java/src/test/java/javaclasses/mealorder/c/vendor/UpdateVendorTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/vendor/UpdateVendorTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * @author Yurii Haidamaka
  */
-@DisplayName("UpdateVendor command should be interpreted by VendorAggregate and")
+@DisplayName("`UpdateVendor` command should be interpreted by `VendorAggregate` and")
 public class UpdateVendorTest extends VendorCommandTest<AddVendor> {
 
     @Override
@@ -52,7 +52,7 @@ public class UpdateVendorTest extends VendorCommandTest<AddVendor> {
     }
 
     @Test
-    @DisplayName("produce UpdateVendor event")
+    @DisplayName("produce `UpdateVendor` event")
     void produceEvent() {
         final AddVendor addVendor = TestVendorCommandFactory.addVendorInstance();
         dispatchCommand(aggregate, envelopeOf(addVendor));

--- a/api-java/src/test/java/javaclasses/mealorder/c/vendor/VendorAggregateRejectionsTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/vendor/VendorAggregateRejectionsTest.java
@@ -21,24 +21,18 @@
 package javaclasses.mealorder.c.vendor;
 
 import io.spine.test.Tests;
-import javaclasses.mealorder.c.command.AddVendor;
-import javaclasses.mealorder.c.command.SetDateRangeForMenu;
-import javaclasses.mealorder.c.rejection.CannotSetDateRange;
-import javaclasses.mealorder.c.rejection.VendorAlreadyExists;
-import javaclasses.mealorder.testdata.TestVendorCommandFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 import static javaclasses.mealorder.c.vendor.VendorAggregateRejections.cannotSetDateRange;
 import static javaclasses.mealorder.c.vendor.VendorAggregateRejections.vendorAlreadyExists;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Yurii Haidamaka
  */
-@DisplayName("VendorAggregateRejections should")
+@DisplayName("`VendorAggregateRejections` should")
 class VendorAggregateRejectionsTest {
 
     @Test
@@ -48,13 +42,13 @@ class VendorAggregateRejectionsTest {
     }
 
     @Test
-    @DisplayName("don't return VendorAlreadyExists rejection for null command")
+    @DisplayName("don't return `VendorAlreadyExists` rejection for null command")
     void doNotThrowVendorAlreadyExistsRejection() {
         assertThrows(NullPointerException.class,
                      () -> vendorAlreadyExists(Tests.nullRef()));
     }
     @Test
-    @DisplayName("don't return CannotSetDateRange rejection for null command")
+    @DisplayName("don't return `CannotSetDateRange` rejection for null command")
     void doNotThrowCannotSetDateRangeRejection() {
         assertThrows(NullPointerException.class,
                      () -> cannotSetDateRange(Tests.nullRef()));

--- a/api-java/src/test/java/javaclasses/mealorder/c/vendor/VendorCommandTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/vendor/VendorCommandTest.java
@@ -25,7 +25,6 @@ import io.spine.client.TestActorRequestFactory;
 import io.spine.core.CommandEnvelope;
 import io.spine.server.aggregate.AggregateCommandTest;
 import javaclasses.mealorder.VendorId;
-import javaclasses.mealorder.c.vendor.VendorAggregate;
 
 /**
  * The parent class for the {@link VendorAggregate} test classes.
@@ -38,7 +37,7 @@ abstract class VendorCommandTest<C extends Message> extends AggregateCommandTest
     private final TestActorRequestFactory requestFactory =
             TestActorRequestFactory.newInstance(getClass());
     VendorAggregate aggregate;
-    VendorId vendorId;
+    private VendorId vendorId;
 
     @Override
     protected void setUp() {
@@ -48,8 +47,8 @@ abstract class VendorCommandTest<C extends Message> extends AggregateCommandTest
 
     @Override
     protected VendorAggregate createAggregate() {
-        vendorId = createVendorId();
-        return new VendorAggregate(vendorId);
+        setVendorId(createVendorId());
+        return new VendorAggregate(getVendorId());
     }
 
     CommandEnvelope envelopeOf(Message commandMessage) {
@@ -61,5 +60,13 @@ abstract class VendorCommandTest<C extends Message> extends AggregateCommandTest
         return VendorId.newBuilder()
                        .setValue("vendor:" + "testVendorNAme")
                        .build();
+    }
+
+    private VendorId getVendorId() {
+        return vendorId;
+    }
+
+    private void setVendorId(VendorId vendorId) {
+        this.vendorId = vendorId;
     }
 }

--- a/api-java/src/test/java/javaclasses/mealorder/c/vendor/VendorsTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/vendor/VendorsTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * @author Yurii Haidamaka
  */
-@DisplayName("Vendors should")
+@DisplayName("`Vendors` should")
 class VendorsTest {
 
     @Test
@@ -61,7 +61,7 @@ class VendorsTest {
     }
 
     @Test
-    @DisplayName("don't check menu without Vendor and MenuDateRange")
+    @DisplayName("don't check menu without `Vendor` and `MenuDateRange`")
     void doNotCheckMEnuWithoutVendorAndMenuDateRange() {
         final Vendor vendor = Vendor.getDefaultInstance();
         final MenuDateRange menuDateRange = MenuDateRange.getDefaultInstance();
@@ -75,7 +75,7 @@ class VendorsTest {
     }
 
     @Test
-    @DisplayName("doesn't validate dateRange without DateRange")
+    @DisplayName("doesn't validate dateRange without `DateRange`")
     void doNotValidateDateRangeWithoutDateRange() {
         assertThrows(NullPointerException.class,
                      () -> isValidDateRange(Tests.nullRef()));


### PR DESCRIPTION
In this small PR we have changed all classes that relate to the vendor aggregate as follows:
-Added package-info.java
-Added static import
-Change return type in all methods from VendorAggregateRegections. For example :
```
    static VendorAlreadyExists vendorAlreadyExists(AddVendor cmd) throws
                                                                  VendorAlreadyExists {
        checkNotNull(cmd);
        final VendorAlreadyExists vendorAlreadyExists = new VendorAlreadyExists(cmd.getVendorId(),
                                                                                cmd.getVendorName(),
                                                                                getCurrentTime());
        throw vendorAlreadyExists;
    }
```
-Change access level for methods from utility classes into package private.

Integration test `MealOrderTest` was added.

Also, we set default percent of coverage to 95% in the .codecov.yml
