### PR TITLE
Order changes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,10 +12,11 @@ coverage:
   - testutil-api/src/main/java/javaclasses/mealorder/testdata/*
 
   status:
-      patch:
-       default:
-          enabled: yes             # must be yes|true to enable this status
-          target: 95%              # specify the target "X%" coverage to hit
+    patch: false
+    project:
+      default:
+        target: 95%
+
 
 comment:
   layout: "header, diff, changes, uncovered"

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregate.java
@@ -53,7 +53,6 @@ import javaclasses.mealorder.c.rejection.MenuNotAvailable;
 import javaclasses.mealorder.c.rejection.OrderAlreadyExists;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static io.spine.time.Time.getCurrentTime;
@@ -66,7 +65,6 @@ import static javaclasses.mealorder.c.order.OrderAggregateRejections.AddDishToOr
 import static javaclasses.mealorder.c.order.OrderAggregateRejections.CancelOrderRejections.cannotCancelProcessedOrder;
 import static javaclasses.mealorder.c.order.OrderAggregateRejections.CreateOrderRejections.orderAlreadyExists;
 import static javaclasses.mealorder.c.order.OrderAggregateRejections.RemoveDishFromOrderRejections.cannotRemoveDishFromNotActiveOrder;
-import static javaclasses.mealorder.c.order.OrderAggregateRejections.RemoveDishFromOrderRejections.cannotRemoveMissingDish;
 import static javaclasses.mealorder.c.order.Orders.checkMenuAvailability;
 import static javaclasses.mealorder.c.order.Orders.getDishFromOrder;
 

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregate.java
@@ -187,11 +187,9 @@ public class OrderAggregate extends Aggregate<OrderId,
     /**
      * Applies the {@link OrderCreated} event.
      *
-     * <p>
-     * Creates new order and changes order aggregate state status on {@code ORDER_ACTIVE}.
-     * Checks if the order with the same id was already created and cancelled. In this case
+     * <p> Creates new order and changes order aggregate state status on {@code ORDER_ACTIVE}.
+     * Checks if the order with the same ID was already created and cancelled. In this case
      * removes all dishes that was added before cancellation.
-     * </p>
      *
      * @param event
      */

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregate.java
@@ -177,7 +177,7 @@ public class OrderAggregate extends Aggregate<OrderId,
      * Checks if the order with the same ID was already created and cancelled. In this case
      * removes all dishes that was added before cancellation.
      *
-     * @param event
+     * @param event is {@code OrderCreated} event that was occurred
      */
     @Apply
     void orderCreated(OrderCreated event) {

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregate.java
@@ -68,6 +68,7 @@ import static javaclasses.mealorder.c.order.OrderAggregateRejections.CreateOrder
 import static javaclasses.mealorder.c.order.OrderAggregateRejections.RemoveDishFromOrderRejections.cannotRemoveDishFromNotActiveOrder;
 import static javaclasses.mealorder.c.order.OrderAggregateRejections.RemoveDishFromOrderRejections.cannotRemoveMissingDish;
 import static javaclasses.mealorder.c.order.Orders.checkMenuAvailability;
+import static javaclasses.mealorder.c.order.Orders.getDishFromOrder;
 
 /**
  * The aggregate managing the state of a {@link Order}.
@@ -148,19 +149,6 @@ public class OrderAggregate extends Aggregate<OrderId,
                                                           .setDish(dish)
                                                           .build();
         return result;
-    }
-
-    private Dish getDishFromOrder(RemoveDishFromOrder cmd, DishId dishId,
-                                  List<Dish> dishesList) throws CannotRemoveMissingDish {
-        Optional<Dish> dish = dishesList.stream()
-                                        .filter(d -> d.getId()
-                                                      .equals(dishId))
-                                        .findFirst();
-
-        if (!dish.isPresent()) {
-            throw cannotRemoveMissingDish(cmd);
-        }
-        return dish.get();
     }
 
     @Assign

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregateRejections.java
@@ -72,13 +72,13 @@ class OrderAggregateRejections {
          * according to the passed parameters.
          *
          * @param cmd the {@code CreateOrder} command which was rejected
-         * @return  OrderAlreadyExists the rejection to return
+         * @throws  OrderAlreadyExists the rejection to throw
          */
-        static OrderAlreadyExists orderAlreadyExists(CreateOrder cmd) {
+        static OrderAlreadyExists orderAlreadyExists(CreateOrder cmd) throws OrderAlreadyExists {
             checkNotNull(cmd);
             final OrderId orderId = cmd.getOrderId();
             final Timestamp timestamp = getCurrentTime();
-            return new OrderAlreadyExists(orderId, timestamp);
+            throw new OrderAlreadyExists(orderId, timestamp);
         }
 
         /**
@@ -86,9 +86,9 @@ class OrderAggregateRejections {
          * according to the passed parameters.
          *
          * @param cmd the {@code CreateOrder} command which was rejected
-         * @return  MenuNotAvailable the rejection to return
+         * @throws  MenuNotAvailable the rejection to throw
          */
-        static MenuNotAvailable menuNotAvailable(CreateOrder cmd) {
+        static MenuNotAvailable menuNotAvailable(CreateOrder cmd) throws MenuNotAvailable {
             checkNotNull(cmd);
             final UserId userId = cmd.getOrderId()
                                      .getUserId();
@@ -96,7 +96,7 @@ class OrderAggregateRejections {
                                          .getVendorId();
             final LocalDate orderDate = cmd.getOrderId()
                                            .getOrderDate();
-            return new MenuNotAvailable(userId, vendorId, orderDate, getCurrentTime());
+            throw new MenuNotAvailable(userId, vendorId, orderDate, getCurrentTime());
         }
     }
 
@@ -116,9 +116,9 @@ class OrderAggregateRejections {
          * according to the passed parameters.
          *
          * @param cmd the {@code AddDishToOrder} command which was rejected
-         * @return  DishVendorMismatch the rejection to return
+         * @throws  DishVendorMismatch the rejection to throw
          */
-        static DishVendorMismatch dishVendorMismatch(AddDishToOrder cmd) {
+        static DishVendorMismatch dishVendorMismatch(AddDishToOrder cmd) throws DishVendorMismatch {
             checkNotNull(cmd);
             final OrderId orderId = cmd.getOrderId();
             final UserId userId = cmd.getOrderId()
@@ -134,7 +134,7 @@ class OrderAggregateRejections {
                                                                 .build();
             final Timestamp timestamp = getCurrentTime();
 
-            return new DishVendorMismatch(orderId, dishId, userId, vendorMismatch, timestamp);
+            throw new DishVendorMismatch(orderId, dishId, userId, vendorMismatch, timestamp);
         }
 
         /**
@@ -142,11 +142,11 @@ class OrderAggregateRejections {
          * according to the passed parameters.
          *
          * @param cmd the {@code AddDishToOrder} command which was rejected
-         * @return  CannotAddDishToNotActiveOrder the rejection to return
+         * @throws  CannotAddDishToNotActiveOrder the rejection to throw
          */
         static CannotAddDishToNotActiveOrder cannotAddDishToNotActiveOrder(
                 AddDishToOrder cmd,
-                OrderStatus orderStatus) {
+                OrderStatus orderStatus) throws CannotAddDishToNotActiveOrder {
             checkNotNull(cmd);
             checkNotNull(orderStatus);
             final OrderId orderId = cmd.getOrderId();
@@ -155,7 +155,7 @@ class OrderAggregateRejections {
             final DishId dishId = cmd.getDish()
                                      .getId();
             final Timestamp timestamp = getCurrentTime();
-            return new CannotAddDishToNotActiveOrder(orderId,
+            throw new CannotAddDishToNotActiveOrder(orderId,
                                                      dishId,
                                                      userId,
                                                      orderStatus,
@@ -179,17 +179,17 @@ class OrderAggregateRejections {
          * according to the passed parameters.
          *
          * @param cmd the {@code RemoveDishFromOrder} command which was rejected
-         * @return  CannotRemoveMissingDish the rejection to return
+         * @throws  CannotRemoveMissingDish the rejection to throw
          */
         static CannotRemoveMissingDish cannotRemoveMissingDish(
-                RemoveDishFromOrder cmd) {
+                RemoveDishFromOrder cmd) throws CannotRemoveMissingDish {
             checkNotNull(cmd);
             final OrderId orderId = cmd.getOrderId();
             final UserId userId = cmd.getOrderId()
                                      .getUserId();
             final DishId dishId = cmd.getDishId();
             final Timestamp timestamp = getCurrentTime();
-            return new CannotRemoveMissingDish(orderId, userId, dishId, timestamp);
+            throw new CannotRemoveMissingDish(orderId, userId, dishId, timestamp);
         }
 
         /**
@@ -197,18 +197,18 @@ class OrderAggregateRejections {
          * according to the passed parameters.
          *
          * @param cmd the {@code RemoveDishFromOrder} command which was rejected
-         * @return CannotRemoveDishFromNotActiveOrder the rejection to return
+         * @throws CannotRemoveDishFromNotActiveOrder the rejection to throw
          */
         static CannotRemoveDishFromNotActiveOrder cannotRemoveDishFromNotActiveOrder(
                 RemoveDishFromOrder cmd,
-                OrderStatus orderStatus) {
+                OrderStatus orderStatus) throws CannotRemoveDishFromNotActiveOrder {
             checkNotNull(cmd);
             final OrderId orderId = cmd.getOrderId();
             final UserId userId = cmd.getOrderId()
                                      .getUserId();
             final DishId dishId = cmd.getDishId();
             final Timestamp timestamp = getCurrentTime();
-            return new CannotRemoveDishFromNotActiveOrder(orderId,
+            throw new CannotRemoveDishFromNotActiveOrder(orderId,
                                                           dishId,
                                                           userId,
                                                           orderStatus,
@@ -232,15 +232,16 @@ class OrderAggregateRejections {
          * according to the passed parameters.
          *
          * @param cmd the {@code CancelOrder} command which was rejected
-         * @return CannotCancelProcessedOrder the rejection to return
+         * @throws CannotCancelProcessedOrder the rejection to throw
          */
-        static CannotCancelProcessedOrder cannotCancelProcessedOrder(CancelOrder cmd) {
+        static CannotCancelProcessedOrder cannotCancelProcessedOrder(CancelOrder cmd) throws
+                                                                                      CannotCancelProcessedOrder {
             checkNotNull(cmd);
             final OrderId orderId = cmd.getOrderId();
             final UserId userId = cmd.getOrderId()
                                      .getUserId();
             final Timestamp timestamp = getCurrentTime();
-            return new CannotCancelProcessedOrder(orderId, userId, timestamp);
+            throw new CannotCancelProcessedOrder(orderId, userId, timestamp);
         }
     }
 }

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregateRejections.java
@@ -68,7 +68,7 @@ class OrderAggregateRejections {
         }
 
         /**
-         * Constructs and returns the {@link OrderAlreadyExists} rejection
+         * Constructs and throws the {@link OrderAlreadyExists} rejection
          * according to the passed parameters.
          *
          * @param cmd the {@code CreateOrder} command which was rejected
@@ -82,7 +82,7 @@ class OrderAggregateRejections {
         }
 
         /**
-         * Constructs and returns the {@link MenuNotAvailable} rejection
+         * Constructs and throws the {@link MenuNotAvailable} rejection
          * according to the passed parameters.
          *
          * @param cmd the {@code CreateOrder} command which was rejected
@@ -112,7 +112,7 @@ class OrderAggregateRejections {
         }
 
         /**
-         * Constructs and returns the {@link DishVendorMismatch} rejection
+         * Constructs and throws the {@link DishVendorMismatch} rejection
          * according to the passed parameters.
          *
          * @param cmd the {@code AddDishToOrder} command which was rejected
@@ -138,7 +138,7 @@ class OrderAggregateRejections {
         }
 
         /**
-         * Constructs and returns the {@link CannotAddDishToNotActiveOrder} rejection
+         * Constructs and throws the {@link CannotAddDishToNotActiveOrder} rejection
          * according to the passed parameters.
          *
          * @param cmd the {@code AddDishToOrder} command which was rejected
@@ -175,7 +175,7 @@ class OrderAggregateRejections {
         }
 
         /**
-         * Constructs and returns the {@link CannotRemoveMissingDish} rejection
+         * Constructs and throws the {@link CannotRemoveMissingDish} rejection
          * according to the passed parameters.
          *
          * @param cmd the {@code RemoveDishFromOrder} command which was rejected
@@ -193,7 +193,7 @@ class OrderAggregateRejections {
         }
 
         /**
-         * Constructs and returns the {@link CannotRemoveDishFromNotActiveOrder} rejection
+         * Constructs and throws the {@link CannotRemoveDishFromNotActiveOrder} rejection
          * according to the passed parameters.
          *
          * @param cmd the {@code RemoveDishFromOrder} command which was rejected
@@ -228,7 +228,7 @@ class OrderAggregateRejections {
         }
 
         /**
-         * Constructs and returns the {@link CannotCancelProcessedOrder} rejection
+         * Constructs and throws the {@link CannotCancelProcessedOrder} rejection
          * according to the passed parameters.
          *
          * @param cmd the {@code CancelOrder} command which was rejected

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/OrderAggregateRejections.java
@@ -48,7 +48,7 @@ import static io.spine.time.Time.getCurrentTime;
  *
  * @author Vlad Kozachenko
  */
-public class OrderAggregateRejections {
+class OrderAggregateRejections {
 
     /**
      * Prevent instantiation of this utility class.
@@ -59,7 +59,7 @@ public class OrderAggregateRejections {
     /**
      * Utility class for working with {@link CreateOrder} command rejections.
      */
-    public static class CreateOrderRejections {
+    static class CreateOrderRejections {
 
         /**
          * Prevent instantiation of this utility class.
@@ -74,7 +74,7 @@ public class OrderAggregateRejections {
          * @param cmd the {@code CreateOrder} command which was rejected
          * @return  OrderAlreadyExists the rejection to return
          */
-        public static OrderAlreadyExists orderAlreadyExists(CreateOrder cmd) {
+        static OrderAlreadyExists orderAlreadyExists(CreateOrder cmd) {
             checkNotNull(cmd);
             final OrderId orderId = cmd.getOrderId();
             final Timestamp timestamp = getCurrentTime();
@@ -88,7 +88,7 @@ public class OrderAggregateRejections {
          * @param cmd the {@code CreateOrder} command which was rejected
          * @return  MenuNotAvailable the rejection to return
          */
-        public static MenuNotAvailable menuNotAvailable(CreateOrder cmd) {
+        static MenuNotAvailable menuNotAvailable(CreateOrder cmd) {
             checkNotNull(cmd);
             final UserId userId = cmd.getOrderId()
                                      .getUserId();
@@ -103,7 +103,7 @@ public class OrderAggregateRejections {
     /**
      * Utility class for working with {@link AddDishToOrder} command rejections.
      */
-    public static class AddDishToOrderRejections {
+    static class AddDishToOrderRejections {
 
         /**
          * Prevent instantiation of this utility class.
@@ -118,7 +118,7 @@ public class OrderAggregateRejections {
          * @param cmd the {@code AddDishToOrder} command which was rejected
          * @return  DishVendorMismatch the rejection to return
          */
-        public static DishVendorMismatch dishVendorMismatch(AddDishToOrder cmd) {
+        static DishVendorMismatch dishVendorMismatch(AddDishToOrder cmd) {
             checkNotNull(cmd);
             final OrderId orderId = cmd.getOrderId();
             final UserId userId = cmd.getOrderId()
@@ -144,7 +144,7 @@ public class OrderAggregateRejections {
          * @param cmd the {@code AddDishToOrder} command which was rejected
          * @return  CannotAddDishToNotActiveOrder the rejection to return
          */
-        public static CannotAddDishToNotActiveOrder cannotAddDishToNotActiveOrder(
+        static CannotAddDishToNotActiveOrder cannotAddDishToNotActiveOrder(
                 AddDishToOrder cmd,
                 OrderStatus orderStatus) {
             checkNotNull(cmd);
@@ -166,7 +166,7 @@ public class OrderAggregateRejections {
     /**
      * Utility class for working with {@link RemoveDishFromOrder} command rejections.
      */
-    public static class RemoveDishFromOrderRejections {
+    static class RemoveDishFromOrderRejections {
 
         /**
          * Prevent instantiation of this utility class.
@@ -181,7 +181,7 @@ public class OrderAggregateRejections {
          * @param cmd the {@code RemoveDishFromOrder} command which was rejected
          * @return  CannotRemoveMissingDish the rejection to return
          */
-        public static CannotRemoveMissingDish cannotRemoveMissingDish(
+        static CannotRemoveMissingDish cannotRemoveMissingDish(
                 RemoveDishFromOrder cmd) {
             checkNotNull(cmd);
             final OrderId orderId = cmd.getOrderId();
@@ -199,7 +199,7 @@ public class OrderAggregateRejections {
          * @param cmd the {@code RemoveDishFromOrder} command which was rejected
          * @return CannotRemoveDishFromNotActiveOrder the rejection to return
          */
-        public static CannotRemoveDishFromNotActiveOrder cannotRemoveDishFromNotActiveOrder(
+        static CannotRemoveDishFromNotActiveOrder cannotRemoveDishFromNotActiveOrder(
                 RemoveDishFromOrder cmd,
                 OrderStatus orderStatus) {
             checkNotNull(cmd);
@@ -219,7 +219,7 @@ public class OrderAggregateRejections {
     /**
      * Utility class for working with {@link CancelOrder} command rejections.
      */
-    public static class CancelOrderRejections {
+    static class CancelOrderRejections {
 
         /**
          * Prevent instantiation of this utility class.
@@ -234,7 +234,7 @@ public class OrderAggregateRejections {
          * @param cmd the {@code CancelOrder} command which was rejected
          * @return CannotCancelProcessedOrder the rejection to return
          */
-        public static CannotCancelProcessedOrder cannotCancelProcessedOrder(CancelOrder cmd) {
+        static CannotCancelProcessedOrder cannotCancelProcessedOrder(CancelOrder cmd) {
             checkNotNull(cmd);
             final OrderId orderId = cmd.getOrderId();
             final UserId userId = cmd.getOrderId()

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/OrderRepository.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/OrderRepository.java
@@ -44,10 +44,10 @@ public class OrderRepository extends AggregateRepository<OrderId, OrderAggregate
     }
 
     /**
-     * Route events to aggregate instances with correct ids.
+     * Route events to aggregate instances with correct IDs.
      *
-     * <p>Extract order ids from received events on which the order aggregate
-     * have to react. Checks if the instances with this ids already created.
+     * <p>Extract order IDs from received events on which the order aggregate
+     * have to react. Checks if the instances with this IDs already created.
      * And routes events to correct instances.
      */
     private void setUpEventRouting() {
@@ -70,8 +70,8 @@ public class OrderRepository extends AggregateRepository<OrderId, OrderAggregate
      *
      * <p>Checks each order whether it is in repository.
      *
-     * @param orderList list of orders where ids may be extracted.
-     * @return set of found ids.
+     * @param orderList list of orders where IDs may be extracted.
+     * @return set of found IDs.
      */
     private Set<OrderId> filterOrderIds(List<Order> orderList) {
         final Set<OrderId> orderIdSet =

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/Orders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/Orders.java
@@ -76,7 +76,7 @@ class Orders {
      * Finds vendor for order.
      *
      * @param orderId ID of the order for which vendor have to be found.
-     * @return Optional of vendor.
+     * @return Optional of {@code Vendor}.
      */
     static Optional<VendorAggregate> getVendorAggregateForOrder(OrderId orderId) throws
                                                                                  MenuNotAvailable {

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/Orders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/Orders.java
@@ -48,7 +48,7 @@ import static javaclasses.mealorder.c.order.OrderAggregateRejections.RemoveDishF
  *
  * @author Vlad Kozachenko
  */
-public class Orders {
+class Orders {
 
     /**
      * Prevent instantiation of this utility class.

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/Orders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/Orders.java
@@ -70,7 +70,7 @@ public class Orders {
     /**
      * Finds vendor for order.
      *
-     * @param orderId id of the order for which vendor have to be found.
+     * @param orderId ID of the order for which vendor have to be found.
      * @return Optional of vendor.
      */
     public static Optional<VendorAggregate> getVendorAggregateForOrder(OrderId orderId) throws
@@ -86,7 +86,7 @@ public class Orders {
     /**
      * Checks whether the menu is available on the date of the order.
      *
-     * @param cmd command that contains order id and menu id that may be checked.
+     * @param cmd command that contains order ID and menu ID that may be checked.
      * @throws MenuNotAvailable if vendor or menu doesn't exist or
      *                          if the menu date range doesn't include order date.
      */

--- a/api-java/src/main/java/javaclasses/mealorder/c/order/Orders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/order/Orders.java
@@ -58,7 +58,7 @@ public class Orders {
      * @param orderDate order date to check
      * @return boolean true if there is a menu on the order date
      */
-    public static boolean checkRangeIncludesDate(MenuDateRange range, LocalDate orderDate) {
+    static boolean checkRangeIncludesDate(MenuDateRange range, LocalDate orderDate) {
         checkNotNull(range);
         checkNotNull(orderDate);
         final Comparator<LocalDate> comparator = new LocalDateComparator();
@@ -73,7 +73,7 @@ public class Orders {
      * @param orderId ID of the order for which vendor have to be found.
      * @return Optional of vendor.
      */
-    public static Optional<VendorAggregate> getVendorAggregateForOrder(OrderId orderId) throws
+    static Optional<VendorAggregate> getVendorAggregateForOrder(OrderId orderId) throws
                                                                                         MenuNotAvailable {
         checkNotNull(orderId);
         final VendorRepository vendorRepository = VendorRepository.getRepository();
@@ -90,7 +90,7 @@ public class Orders {
      * @throws MenuNotAvailable if vendor or menu doesn't exist or
      *                          if the menu date range doesn't include order date.
      */
-    public static void checkMenuAvailability(CreateOrder cmd) throws
+    static void checkMenuAvailability(CreateOrder cmd) throws
                                                               MenuNotAvailable {
         checkNotNull(cmd);
         final OrderId orderId = cmd.getOrderId();

--- a/api-java/src/test/java/javaclasses/mealorder/c/order/AddDishToOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/order/AddDishToOrderTest.java
@@ -135,10 +135,13 @@ public class AddDishToOrderTest extends OrderCommandTest {
         final VendorId expected = INVALID_DISH.getId()
                                               .getMenuId()
                                               .getVendorId();
-        assertEquals(expected, dishVendorMismatch.getVendorMismatch()
-                                                 .getActual());
-        assertEquals(ORDER_ID.getVendorId(), dishVendorMismatch.getVendorMismatch()
-                                                               .getTarget());
+        final VendorId actualVendorId = dishVendorMismatch.getVendorMismatch()
+                                                  .getActual();
+        final VendorId targetVendorId = dishVendorMismatch.getVendorMismatch()
+                                                  .getTarget();
+
+        assertEquals(expected, actualVendorId);
+        assertEquals(ORDER_ID.getVendorId(), targetVendorId);
     }
 
     @Test

--- a/api-java/src/test/java/javaclasses/mealorder/c/order/AddDishToOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/order/AddDishToOrderTest.java
@@ -22,7 +22,6 @@ package javaclasses.mealorder.c.order;
 
 import com.google.common.base.Optional;
 import io.spine.core.Command;
-import io.spine.grpc.StreamObservers;
 import io.spine.server.entity.Repository;
 import javaclasses.mealorder.Order;
 import javaclasses.mealorder.VendorId;
@@ -46,7 +45,6 @@ import static javaclasses.mealorder.testdata.TestOrderCommandFactory.cancelOrder
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.createOrderInstance;
 import static javaclasses.mealorder.testdata.TestValues.DISH1;
 import static javaclasses.mealorder.testdata.TestValues.INVALID_DISH;
-import static javaclasses.mealorder.testdata.TestValues.MENU_ID;
 import static javaclasses.mealorder.testdata.TestValues.ORDER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/api-java/src/test/java/javaclasses/mealorder/c/order/AddDishToOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/order/AddDishToOrderTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static io.spine.grpc.StreamObservers.noOpObserver;
 import static javaclasses.mealorder.OrderStatus.ORDER_ACTIVE;
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.addDishToOrderInstance;
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.cancelOrderInstance;
@@ -55,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author Vlad Kozachenko
  */
-@DisplayName("AddDishToOrder command should be interpreted by OrderAggregate and ")
+@DisplayName("`AddDishToOrder` command should be interpreted by `OrderAggregate` and ")
 public class AddDishToOrderTest extends OrderCommandTest {
 
     @Override
@@ -65,11 +66,11 @@ public class AddDishToOrderTest extends OrderCommandTest {
         final CreateOrder createOrder = createOrderInstance();
         final Command createOrderCommand = requestFactory.command()
                                                          .create(createOrder);
-        commandBus.post(createOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(createOrderCommand, noOpObserver());
     }
 
     @Test
-    @DisplayName("produce DishAddedToOrder event")
+    @DisplayName("produce `DishAddedToOrder` event")
     void produceEvent() {
         final AddDishToOrder addDishToOrder = addDishToOrderInstance();
 
@@ -81,7 +82,7 @@ public class AddDishToOrderTest extends OrderCommandTest {
 
         eventBus.register(dishAddedToOrderSubscriber);
 
-        commandBus.post(addDishToOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(addDishToOrderCommand, noOpObserver());
 
         final DishAddedToOrder event =
                 (DishAddedToOrder) dishAddedToOrderSubscriber.getEventMessage();
@@ -98,7 +99,7 @@ public class AddDishToOrderTest extends OrderCommandTest {
         final Command addDishToOrderCommand = requestFactory.command()
                                                             .create(addDishToOrder);
 
-        commandBus.post(addDishToOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(addDishToOrderCommand, noOpObserver());
 
         final Optional<Repository> repositoryOptional = boundedContext.findRepository(Order.class);
 
@@ -116,7 +117,7 @@ public class AddDishToOrderTest extends OrderCommandTest {
     }
 
     @Test
-    @DisplayName("throw DishVendorMismatch rejection")
+    @DisplayName("throw `DishVendorMismatch` rejection")
     void notAddDish() {
         final AddDishToOrder addDishToOrder = addDishToOrderInstance(ORDER_ID, INVALID_DISH);
         final DishVendorMismatchSubscriber dishVendorMismatchSubscriber
@@ -127,7 +128,7 @@ public class AddDishToOrderTest extends OrderCommandTest {
         rejectionBus.register(dishVendorMismatchSubscriber);
         assertNull(OrderTestEnv.DishVendorMismatchSubscriber.getRejection());
 
-        commandBus.post(addDishToOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(addDishToOrderCommand, noOpObserver());
         assertNotNull(OrderTestEnv.DishVendorMismatchSubscriber.getRejection());
 
         final Rejections.DishVendorMismatch dishVendorMismatch
@@ -143,7 +144,7 @@ public class AddDishToOrderTest extends OrderCommandTest {
     }
 
     @Test
-    @DisplayName("throw CannotAddDishToNotActiveOrder rejection")
+    @DisplayName("throw `CannotAddDishToNotActiveOrder` rejection")
     void notAddDishToNotActiveOrder() {
         final AddDishToOrder addDishToOrder = addDishToOrderInstance();
         final CancelOrder cancelOrder = cancelOrderInstance();
@@ -159,8 +160,8 @@ public class AddDishToOrderTest extends OrderCommandTest {
         rejectionBus.register(rejectionSubscriber);
         assertNull(OrderTestEnv.CannotAddDishToNotActiveOrderSubscriber.getRejection());
 
-        commandBus.post(cancelOrderCommand, StreamObservers.noOpObserver());
-        commandBus.post(addDishToOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(cancelOrderCommand, noOpObserver());
+        commandBus.post(addDishToOrderCommand, noOpObserver());
         assertNotNull(OrderTestEnv.CannotAddDishToNotActiveOrderSubscriber.getRejection());
 
         final Rejections.CannotAddDishToNotActiveOrder rejection

--- a/api-java/src/test/java/javaclasses/mealorder/c/order/CancelOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/order/CancelOrderTest.java
@@ -24,7 +24,6 @@ import com.google.common.base.Optional;
 import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.grpc.MemoizingObserver;
-import io.spine.grpc.StreamObservers;
 import io.spine.server.entity.Repository;
 import javaclasses.mealorder.Order;
 import javaclasses.mealorder.OrderStatus;
@@ -44,13 +43,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.grpc.StreamObservers.memoizingObserver;
+import static io.spine.grpc.StreamObservers.noOpObserver;
 import static javaclasses.mealorder.OrderStatus.ORDER_CANCELED;
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.cancelOrderInstance;
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.createOrderInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.cancelPOWithEmptyReasonInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderInstance;
 import static javaclasses.mealorder.testdata.TestValues.DISH1;
-import static javaclasses.mealorder.testdata.TestValues.MENU_ID;
 import static javaclasses.mealorder.testdata.TestValues.ORDER_ID;
 import static javaclasses.mealorder.testdata.TestValues.USER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,7 +61,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Vlad Kozachenko
  */
-@DisplayName("CancelOrder command should be interpreted by OrderAggregate and ")
+@DisplayName("`CancelOrder` command should be interpreted by `OrderAggregate` and ")
 public class CancelOrderTest extends OrderCommandTest {
 
     final CreateOrder createOrder = createOrderInstance();
@@ -73,11 +72,11 @@ public class CancelOrderTest extends OrderCommandTest {
     @BeforeEach
     public void setUp() {
         super.setUp();
-        commandBus.post(createOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(createOrderCommand, noOpObserver());
     }
 
     @Test
-    @DisplayName("produce OrderCanceled event")
+    @DisplayName("produce `OrderCanceled` event")
     void produceEvent() {
         final CancelOrder cancelOrder = cancelOrderInstance();
 
@@ -88,7 +87,7 @@ public class CancelOrderTest extends OrderCommandTest {
 
         eventBus.register(orderCanceledSubscriber);
 
-        commandBus.post(cancelOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(cancelOrderCommand, noOpObserver());
 
         final OrderCanceled event = (OrderCanceled) orderCanceledSubscriber.getEventMessage();
 
@@ -129,7 +128,7 @@ public class CancelOrderTest extends OrderCommandTest {
     }
 
     @Test
-    @DisplayName("cancel order by react on PurchaseOrderCanceled")
+    @DisplayName("cancel order by react on `PurchaseOrderCanceled`")
     void testOrderCanceledByReact() {
         final AddDishToOrder addDishToOrder = AddDishToOrder.newBuilder()
                                                             .setDish(DISH1)
@@ -137,19 +136,19 @@ public class CancelOrderTest extends OrderCommandTest {
                                                             .build();
         final Command addDishToOrderCommand = requestFactory.command()
                                                             .create(addDishToOrder);
-        commandBus.post(addDishToOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(addDishToOrderCommand, noOpObserver());
 
         final CreatePurchaseOrder createPurchaseOrder = createPurchaseOrderInstance();
         final Command createPOCommand = requestFactory.command()
                                                       .create(createPurchaseOrder);
         ServiceFactory.setPoSenderInstance(mock(PurchaseOrderSender.class));
 
-        commandBus.post(createPOCommand, StreamObservers.noOpObserver());
+        commandBus.post(createPOCommand, noOpObserver());
 
         final CancelPurchaseOrder cancelPurchaseOrder = cancelPOWithEmptyReasonInstance();
         final Command cancelPurchaseOrderCommand = requestFactory.command()
                                                                  .create(cancelPurchaseOrder);
-        commandBus.post(cancelPurchaseOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(cancelPurchaseOrderCommand, noOpObserver());
 
         final Optional<Repository> repositoryOptional = boundedContext.findRepository(Order.class);
 
@@ -165,7 +164,7 @@ public class CancelOrderTest extends OrderCommandTest {
     }
 
     @Test
-    @DisplayName("throw CannotCancelProcessedOrder rejection")
+    @DisplayName("throw `CannotCancelProcessedOrder` rejection")
     void throwsCannotCancelProcessedOrder() {
         final AddDishToOrder addDishToOrder = AddDishToOrder.newBuilder()
                                                             .setDish(DISH1)
@@ -173,14 +172,14 @@ public class CancelOrderTest extends OrderCommandTest {
                                                             .build();
         final Command addDishToOrderCommand = requestFactory.command()
                                                             .create(addDishToOrder);
-        commandBus.post(addDishToOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(addDishToOrderCommand, noOpObserver());
 
         final CreatePurchaseOrder createPurchaseOrder = createPurchaseOrderInstance();
         final Command createPOCommand = requestFactory.command()
                                                       .create(createPurchaseOrder);
         ServiceFactory.setPoSenderInstance(mock(PurchaseOrderSender.class));
 
-        commandBus.post(createPOCommand, StreamObservers.noOpObserver());
+        commandBus.post(createPOCommand, noOpObserver());
 
         final CancelOrder cancelOrder = cancelOrderInstance();
 
@@ -194,7 +193,7 @@ public class CancelOrderTest extends OrderCommandTest {
 
         assertNull(CannotCancelProcessedOrderSubscriber.getRejection());
 
-        commandBus.post(cancelOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(cancelOrderCommand, noOpObserver());
 
         assertNotNull(CannotCancelProcessedOrderSubscriber.getRejection());
 

--- a/api-java/src/test/java/javaclasses/mealorder/c/order/OrderAggregateRejectionsTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/order/OrderAggregateRejectionsTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * @author Vlad Kozachenko
  */
-@DisplayName("OrderAggregateRejections should")
+@DisplayName("`OrderAggregateRejections` should")
 class OrderAggregateRejectionsTest {
 
     @Test
@@ -48,7 +48,7 @@ class OrderAggregateRejectionsTest {
     }
 
     @Nested
-    @DisplayName("CreateOrderRejections should")
+    @DisplayName("`CreateOrderRejections` should")
     class CreateOrderRejectionsTest {
 
         @Test
@@ -58,14 +58,14 @@ class OrderAggregateRejectionsTest {
         }
 
         @Test
-        @DisplayName("don't return orderAlreadyExists rejection for null command")
+        @DisplayName("don't return `OrderAlreadyExists` rejection for null command")
         void doNotThrowOrderAlreadyExistsRejection() {
             assertThrows(NullPointerException.class,
                          () -> orderAlreadyExists(Tests.nullRef()));
         }
 
         @Test
-        @DisplayName("don't return MenuNotAvailable rejection for null command")
+        @DisplayName("don't return `MenuNotAvailable` rejection for null command")
         void doNotThrowMenuNotAvailableRejection() {
             assertThrows(NullPointerException.class,
                          () -> menuNotAvailable(Tests.nullRef()));
@@ -73,7 +73,7 @@ class OrderAggregateRejectionsTest {
     }
 
     @Nested
-    @DisplayName("AddDishToOrderRejections should")
+    @DisplayName("`AddDishToOrderRejections` should")
     class AddDishToOrderRejectionsTest {
 
         @Test
@@ -85,7 +85,7 @@ class OrderAggregateRejectionsTest {
 
 
         @Test
-        @DisplayName("don't return DishVendorMismatch rejection for null command")
+        @DisplayName("don't return `DishVendorMismatch` rejection for null command")
         void doNotThrowDishVendorMismatchRejection() {
             assertThrows(NullPointerException.class,
                          () -> dishVendorMismatch(Tests.nullRef()));
@@ -93,7 +93,7 @@ class OrderAggregateRejectionsTest {
 
 
         @Test
-        @DisplayName("don't return CannotAddDishToNotActiveOrder rejection for null command")
+        @DisplayName("don't return `CannotAddDishToNotActiveOrder` rejection for null command")
         void doNotThrowCannotAddDishToNotActiveOrderRejection() {
             assertThrows(NullPointerException.class,
                          () -> cannotAddDishToNotActiveOrder(Tests.nullRef(), Tests.nullRef()));
@@ -101,7 +101,7 @@ class OrderAggregateRejectionsTest {
     }
 
     @Nested
-    @DisplayName("RemoveDishFromOrderRejections should")
+    @DisplayName("`RemoveDishFromOrderRejections` should")
     class RemoveDishFromOrderRejectionsTest {
 
         @Test
@@ -113,14 +113,14 @@ class OrderAggregateRejectionsTest {
 
 
         @Test
-        @DisplayName("don't return CannotRemoveMissingDish rejection for null command")
+        @DisplayName("don't return `CannotRemoveMissingDish` rejection for null command")
         void doNotThrowCannotRemoveMissingDishRejection() {
             assertThrows(NullPointerException.class,
                          () -> cannotRemoveMissingDish(Tests.nullRef()));
         }
 
         @Test
-        @DisplayName("don't return CannotRemoveDishFromNotActiveOrder rejection for null command")
+        @DisplayName("don't return `CannotRemoveDishFromNotActiveOrder` rejection for null command")
         void doNotThrowCannotRemoveDishFromNotActiveOrderRejection() {
             assertThrows(NullPointerException.class,
                          () -> cannotRemoveDishFromNotActiveOrder(Tests.nullRef(), Tests.nullRef()));
@@ -128,7 +128,7 @@ class OrderAggregateRejectionsTest {
     }
 
     @Nested
-    @DisplayName("CancelOrderRejections should")
+    @DisplayName("`CancelOrderRejections` should")
     class CancelOrderRejectionsTest {
 
         @Test
@@ -140,7 +140,7 @@ class OrderAggregateRejectionsTest {
 
 
         @Test
-        @DisplayName("don't return CannotCancelProcessedOrder rejection for null command")
+        @DisplayName("don't return `CannotCancelProcessedOrder` rejection for null command")
         void doNotThrowCannotCancelProcessedOrderRejection() {
             assertThrows(NullPointerException.class,
                          () -> cannotCancelProcessedOrder(Tests.nullRef()));

--- a/api-java/src/test/java/javaclasses/mealorder/c/order/OrderCommandTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/order/OrderCommandTest.java
@@ -31,6 +31,8 @@ import io.spine.server.rejection.RejectionBus;
 import javaclasses.mealorder.c.BoundedContexts;
 import javaclasses.mealorder.testdata.TestVendorCommandFactory;
 
+import static io.spine.grpc.StreamObservers.noOpObserver;
+
 /**
  * @author Vlad Kozachenko
  */
@@ -54,16 +56,16 @@ public class OrderCommandTest {
                 requestFactory.command()
                               .create(TestVendorCommandFactory.addVendorInstance());
 
-        commandBus.post(addVendor, StreamObservers.noOpObserver());
+        commandBus.post(addVendor, noOpObserver());
 
         final Command importMenu =
                 requestFactory.command()
                               .create(TestVendorCommandFactory.importMenuInstance());
-        commandBus.post(importMenu, StreamObservers.noOpObserver());
+        commandBus.post(importMenu, noOpObserver());
 
         final Command setDateRangeForMenu =
                 requestFactory.command()
                               .create(TestVendorCommandFactory.setDateRangeForMenuInstance());
-        commandBus.post(setDateRangeForMenu, StreamObservers.noOpObserver());
+        commandBus.post(setDateRangeForMenu, noOpObserver());
     }
 }

--- a/api-java/src/test/java/javaclasses/mealorder/c/order/OrderProcessedTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/order/OrderProcessedTest.java
@@ -38,7 +38,6 @@ import static javaclasses.mealorder.OrderStatus.ORDER_PROCESSED;
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.createOrderInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderInstance;
 import static javaclasses.mealorder.testdata.TestValues.DISH1;
-import static javaclasses.mealorder.testdata.TestValues.MENU_ID;
 import static javaclasses.mealorder.testdata.TestValues.ORDER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,7 +46,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Vlad Kozachenko
  */
-@DisplayName("OrderAggregate should react on PurchaseOrderCreated command and")
+@DisplayName("`OrderAggregate` should react on `PurchaseOrderCreated` command and")
 public class OrderProcessedTest extends OrderCommandTest {
 
     final CreateOrder createOrder = createOrderInstance();

--- a/api-java/src/test/java/javaclasses/mealorder/c/order/OrdersTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/order/OrdersTest.java
@@ -52,32 +52,32 @@ class OrdersTest {
     }
 
     @Test
-    @DisplayName("return 'true' if the menu is available on the ordering date")
+    @DisplayName("return `true` if the menu is available on the ordering date")
     void returnTrueForExistingMenu() {
         assertTrue(checkRangeIncludesDate(MENU_DATE_RANGE, ORDER_ID.getOrderDate()));
     }
 
     @Test
-    @DisplayName("return false order has no date")
+    @DisplayName("return `false` order has no date")
     void returnFalseForOrderWithoutDate() {
         assertFalse(checkRangeIncludesDate(MENU_DATE_RANGE, OrderId.getDefaultInstance()
                                                                    .getOrderDate()));
     }
 
     @Test
-    @DisplayName("return false if order date is after menu end date")
+    @DisplayName("return `false` if order date is after menu end date")
     void returnFalseForOrderDateAfterMenu() {
         assertFalse(checkRangeIncludesDate(MENU_DATE_RANGE, INVALID_START_DATE));
     }
 
     @Test
-    @DisplayName("return false if order date is before menu end date")
+    @DisplayName("return `false` if order date is before menu end date")
     void returnFalseForOrderDateBeforeMenu() {
         assertFalse(checkRangeIncludesDate(MENU_DATE_RANGE, INVALID_END_DATE));
     }
 
     @Test
-    @DisplayName("throw NullPointerException if checkRangeIncludesDate " +
+    @DisplayName("throw `NullPointerException` if `checkRangeIncludesDate` " +
             "was called with null as any of arguments")
     void throwNullPointerOnCheckRangeIncludesDate() {
         assertThrows(NullPointerException.class,
@@ -90,14 +90,14 @@ class OrdersTest {
     }
 
     @Test
-    @DisplayName("throw NullPointerException if getVendorAggregateForOrder " +
+    @DisplayName("throw `NullPointerException` if `getVendorAggregateForOrder` " +
             "was called with null as argument")
     void throwNullPointerOnGetVendorAggregateForOrder() {
         assertThrows(NullPointerException.class, () -> getVendorAggregateForOrder(Tests.nullRef()));
     }
 
     @Test
-    @DisplayName("throw NullPointerException if checkMenuAvailability " +
+    @DisplayName("throw `NullPointerException` if `checkMenuAvailability` " +
             "was called with null as argument")
     void throwNullPointerOnCheckMenuAvailability() {
         assertThrows(NullPointerException.class, () -> checkMenuAvailability(Tests.nullRef()));

--- a/api-java/src/test/java/javaclasses/mealorder/c/order/RemoveDishFromOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/order/RemoveDishFromOrderTest.java
@@ -22,7 +22,6 @@ package javaclasses.mealorder.c.order;
 
 import com.google.common.base.Optional;
 import io.spine.core.Command;
-import io.spine.grpc.StreamObservers;
 import io.spine.server.entity.Repository;
 import javaclasses.mealorder.Order;
 import javaclasses.mealorder.c.command.AddDishToOrder;
@@ -38,13 +37,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static io.spine.grpc.StreamObservers.noOpObserver;
 import static javaclasses.mealorder.OrderStatus.ORDER_ACTIVE;
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.addDishToOrderInstance;
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.cancelOrderInstance;
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.createOrderInstance;
 import static javaclasses.mealorder.testdata.TestOrderCommandFactory.removeDishFromOrderInstance;
 import static javaclasses.mealorder.testdata.TestValues.DISH1;
-import static javaclasses.mealorder.testdata.TestValues.MENU_ID;
 import static javaclasses.mealorder.testdata.TestValues.ORDER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -54,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author Vlad Kozachenko
  */
-@DisplayName("RemoveDishFromOrder command should be interpreted by OrderAggregate and ")
+@DisplayName("`RemoveDishFromOrder` command should be interpreted by `OrderAggregate` and ")
 public class RemoveDishFromOrderTest extends OrderCommandTest {
 
     @Override
@@ -64,11 +63,11 @@ public class RemoveDishFromOrderTest extends OrderCommandTest {
         final CreateOrder createOrder = createOrderInstance();
         final Command createOrderCommand = requestFactory.command()
                                                          .create(createOrder);
-        commandBus.post(createOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(createOrderCommand, noOpObserver());
     }
 
     @Test
-    @DisplayName("produce DishRemovedFromOrder event")
+    @DisplayName("produce `DishRemovedFromOrder` event")
     void produceEvent() {
         final DishRemovedFromOrderSubscriber eventSubscriber
                 = new DishRemovedFromOrderSubscriber();
@@ -77,13 +76,13 @@ public class RemoveDishFromOrderTest extends OrderCommandTest {
         final AddDishToOrder addDishToOrder = addDishToOrderInstance();
         final Command addDishToOrderCommand = requestFactory.command()
                                                             .create(addDishToOrder);
-        commandBus.post(addDishToOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(addDishToOrderCommand, noOpObserver());
 
         final RemoveDishFromOrder removeDishFromOrder = removeDishFromOrderInstance(ORDER_ID,
                                                                                     DISH1.getId());
         final Command removeDishFromOrderCommand = requestFactory.command()
                                                                  .create(removeDishFromOrder);
-        commandBus.post(removeDishFromOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(removeDishFromOrderCommand, noOpObserver());
 
         final DishRemovedFromOrder event = (DishRemovedFromOrder) eventSubscriber.getEventMessage();
 
@@ -98,13 +97,13 @@ public class RemoveDishFromOrderTest extends OrderCommandTest {
         final AddDishToOrder addDishToOrder = addDishToOrderInstance();
         final Command addDishToOrderCommand = requestFactory.command()
                                                             .create(addDishToOrder);
-        commandBus.post(addDishToOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(addDishToOrderCommand, noOpObserver());
 
-        final RemoveDishFromOrder removeDishFromOrder = removeDishFromOrderInstance(ORDER_ID,
-                                                                                    DISH1.getId());
+        final RemoveDishFromOrder removeDishFromOrder =
+                removeDishFromOrderInstance(ORDER_ID, DISH1.getId());
         final Command removeDishFromOrderCommand = requestFactory.command()
                                                                  .create(removeDishFromOrder);
-        commandBus.post(removeDishFromOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(removeDishFromOrderCommand, noOpObserver());
 
         final Optional<Repository> repositoryOptional = boundedContext.findRepository(Order.class);
 
@@ -122,21 +121,21 @@ public class RemoveDishFromOrderTest extends OrderCommandTest {
     }
 
     @Test
-    @DisplayName("throw CannotRemoveMissingDish rejection")
+    @DisplayName("throw `CannotRemoveMissingDish` rejection")
     void notRemoveDish() {
         final OrderTestEnv.CannotRemoveMissingDishSubscriber rejectionSubscriber
                 = new OrderTestEnv.CannotRemoveMissingDishSubscriber();
 
         rejectionBus.register(rejectionSubscriber);
 
-        final RemoveDishFromOrder removeDishFromOrder = removeDishFromOrderInstance(ORDER_ID,
-                                                                                    DISH1.getId());
+        final RemoveDishFromOrder removeDishFromOrder =
+                removeDishFromOrderInstance(ORDER_ID, DISH1.getId());
         final Command removeDishFromOrderCommand = requestFactory.command()
                                                                  .create(removeDishFromOrder);
 
         assertNull(OrderTestEnv.CannotRemoveMissingDishSubscriber.getRejection());
 
-        commandBus.post(removeDishFromOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(removeDishFromOrderCommand, noOpObserver());
 
         assertNotNull(OrderTestEnv.CannotRemoveMissingDishSubscriber.getRejection());
 
@@ -148,7 +147,7 @@ public class RemoveDishFromOrderTest extends OrderCommandTest {
     }
 
     @Test
-    @DisplayName("throw CannotRemoveDishFromNotActiveOrder rejection")
+    @DisplayName("throw `CannotRemoveDishFromNotActiveOrder` rejection")
     void notRemoveDishFromNotActiveOrder() {
         final CannotRemoveDishFromNotActiveOrderSubscriber rejectionSubscriber
                 = new CannotRemoveDishFromNotActiveOrderSubscriber();
@@ -158,21 +157,21 @@ public class RemoveDishFromOrderTest extends OrderCommandTest {
         final AddDishToOrder addDishToOrder = addDishToOrderInstance();
         final Command addDishToOrderCommand = requestFactory.command()
                                                             .create(addDishToOrder);
-        commandBus.post(addDishToOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(addDishToOrderCommand, noOpObserver());
 
         final CancelOrder cancelOrder = cancelOrderInstance();
         final Command cancelOrderCommand = requestFactory.command()
                                                          .create(cancelOrder);
-        commandBus.post(cancelOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(cancelOrderCommand, noOpObserver());
 
-        final RemoveDishFromOrder removeDishFromOrder = removeDishFromOrderInstance(ORDER_ID,
-                                                                                    DISH1.getId());
+        final RemoveDishFromOrder removeDishFromOrder =
+                removeDishFromOrderInstance(ORDER_ID, DISH1.getId());
         final Command removeDishFromOrderCommand = requestFactory.command()
                                                                  .create(removeDishFromOrder);
 
         assertNull(OrderTestEnv.CannotRemoveDishFromNotActiveOrderSubscriber.getRejection());
 
-        commandBus.post(removeDishFromOrderCommand, StreamObservers.noOpObserver());
+        commandBus.post(removeDishFromOrderCommand, noOpObserver());
 
         assertNotNull(OrderTestEnv.CannotRemoveDishFromNotActiveOrderSubscriber.getRejection());
 


### PR DESCRIPTION
In this small PR we have changed all classes that relate to the order aggregate as follows:
- Corrected mistakes in Javadoc
- Used static imports if it possible
- Updated display names for tests (concluded classes and methods in backticks)
- Used package private access modifiers for order utility classes methods
- Moved utility methods from `OrderAggregate` to `Orders`