### PR TITLE
Po code cleanup

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -82,7 +82,6 @@
     <inspection_tool class="CastConflictsWithInstanceof" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CastThatLosesPrecision" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreIntegerCharCasts" value="false" />
-      <option name="ignoreOverflowingByteCasts" value="false" />
     </inspection_tool>
     <inspection_tool class="CastToConcreteClass" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="ignoreAbstractClasses" value="true" />
@@ -534,7 +533,7 @@
     <inspection_tool class="PackageInMultipleModules" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_regex" value="[a-z]+\d*[a-z]*" />
-      <option name="m_minLength" value="2" />
+      <option name="m_minLength" value="1" />
       <option name="m_maxLength" value="16" />
     </inspection_tool>
     <inspection_tool class="PackageVisibleField" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/api-java/src/main/java/javaclasses/mealorder/PurchaseOrderSender.java
+++ b/api-java/src/main/java/javaclasses/mealorder/PurchaseOrderSender.java
@@ -23,7 +23,7 @@ package javaclasses.mealorder;
 import io.spine.net.EmailAddress;
 
 /**
- * Utility interface managing the sending process of a purchase order
+ * Interface for service managing the sending process of a purchase order
  * to the vendor.
  *
  * @author Yegor Udovchenko
@@ -34,10 +34,8 @@ public interface PurchaseOrderSender {
      * Sends purchase order to the vendor email address.
      *
      * @param purchaseOrder purchase order to send
-     * @param senderEmail   the email of the sender
-     * @param vendorEmail   the email of the vendor
+     * @param senderEmail   the sender email address
+     * @param vendorEmail   the vendor email address
      */
-    void send(PurchaseOrder purchaseOrder,
-              EmailAddress senderEmail,
-              EmailAddress vendorEmail);
+    void send(PurchaseOrder purchaseOrder, EmailAddress senderEmail, EmailAddress vendorEmail);
 }

--- a/api-java/src/main/java/javaclasses/mealorder/ServiceFactory.java
+++ b/api-java/src/main/java/javaclasses/mealorder/ServiceFactory.java
@@ -35,7 +35,9 @@ import static io.spine.util.Exceptions.newIllegalStateException;
 public class ServiceFactory {
 
     // TODO 2/20/2018[yegor.udovchenko]: Github issue : Purchase Order Sending Service #44
-    private static PurchaseOrderSender poSenderInstance = null;
+    private static PurchaseOrderSender poSenderInstance =
+            (purchaseOrder, senderEmail, vendorEmail) -> {
+            };
 
     /** Prevents instantiation of this utility class. */
     private ServiceFactory() {
@@ -54,10 +56,9 @@ public class ServiceFactory {
      * Setter method is used to substitute {@code PurchaseOrderSender}
      * with a mock instance for tests.
      *
-     * <p>Applicable only in test runtime
-     * environment.
+     * <p>Applicable only in test runtime environment.
      *
-     * @param poSenderInstance purchase order sender
+     * @param poSenderInstance purchase order sender mock
      * @throws IllegalStateException if this method is called not from test
      */
     public static void setPoSenderInstance(

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregate.java
@@ -59,10 +59,10 @@ import static javaclasses.mealorder.PurchaseOrderStatus.DELIVERED;
 import static javaclasses.mealorder.PurchaseOrderStatus.INVALID;
 import static javaclasses.mealorder.PurchaseOrderStatus.SENT;
 import static javaclasses.mealorder.PurchaseOrderStatus.VALID;
-import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.throwCannotCancelDeliveredPurchaseOrder;
-import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.throwCannotCreatePurchaseOrder;
-import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.throwCannotMarkPurchaseOrderAsDelivered;
-import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.throwCannotOverruleValidationOfNotInvalidPO;
+import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.cannotCancelDeliveredPurchaseOrder;
+import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.cannotCreatePurchaseOrder;
+import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.cannotMarkPurchaseOrderAsDelivered;
+import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.cannotOverruleValidationOfNotInvalidPO;
 import static javaclasses.mealorder.c.po.PurchaseOrders.findInvalidOrders;
 import static javaclasses.mealorder.c.po.PurchaseOrders.hasInvalidOrders;
 import static javaclasses.mealorder.c.po.PurchaseOrders.isAllowedPurchaseOrderCreation;
@@ -95,7 +95,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
             throws CannotCreatePurchaseOrder {
 
         if (!isAllowedPurchaseOrderCreation(cmd)) {
-            throwCannotCreatePurchaseOrder(cmd);
+            cannotCreatePurchaseOrder(cmd);
         }
 
         Triplet result;
@@ -134,7 +134,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
             throws CannotOverruleValidationOfNotInvalidPO {
 
         if (!isAllowedToMarkAsValid()) {
-            throwCannotOverruleValidationOfNotInvalidPO(cmd);
+            cannotOverruleValidationOfNotInvalidPO(cmd);
         }
 
         final PurchaseOrderValidationOverruled overruledEvent =
@@ -156,7 +156,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
     PurchaseOrderDelivered handle(MarkPurchaseOrderAsDelivered cmd)
             throws CannotMarkPurchaseOrderAsDelivered {
         if (!isAllowedToMarkAsDelivered()) {
-            throwCannotMarkPurchaseOrderAsDelivered(cmd);
+            cannotMarkPurchaseOrderAsDelivered(cmd);
         }
         return createPOMarkedAsDeliveredEvent(cmd);
     }
@@ -165,7 +165,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
     PurchaseOrderCanceled handle(CancelPurchaseOrder cmd)
             throws CannotCancelDeliveredPurchaseOrder {
         if (!isAllowedToCancel()) {
-            throwCannotCancelDeliveredPurchaseOrder(cmd);
+            cannotCancelDeliveredPurchaseOrder(cmd);
         }
         return createPOCanceledEvent(cmd, getState().getOrderList());
     }

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregate.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregate.java
@@ -99,7 +99,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
                                                                          CannotCreatePurchaseOrder {
 
         if (!isAllowedPurchaseOrderCreation(cmd)) {
-            cannotCreatePurchaseOrder(cmd);
+            throw cannotCreatePurchaseOrder(cmd);
         }
 
         Triplet result;
@@ -135,7 +135,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
             throws CannotOverruleValidationOfNotInvalidPO {
 
         if (!isAllowedToMarkAsValid()) {
-            cannotOverruleValidationOfNotInvalidPO(cmd);
+            throw cannotOverruleValidationOfNotInvalidPO(cmd);
         }
 
         final PurchaseOrderValidationOverruled overruledEvent =
@@ -157,7 +157,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
     PurchaseOrderDelivered handle(MarkPurchaseOrderAsDelivered cmd) throws
                                                                     CannotMarkPurchaseOrderAsDelivered {
         if (!isAllowedToMarkAsDelivered()) {
-            cannotMarkPurchaseOrderAsDelivered(cmd);
+            throw cannotMarkPurchaseOrderAsDelivered(cmd);
         }
         final PurchaseOrderDelivered poMarkedAsDeliveredEvent = createPOMarkedAsDeliveredEvent(cmd);
         return poMarkedAsDeliveredEvent;
@@ -167,7 +167,7 @@ public class PurchaseOrderAggregate extends Aggregate<PurchaseOrderId,
     PurchaseOrderCanceled handle(CancelPurchaseOrder cmd) throws
                                                           CannotCancelDeliveredPurchaseOrder {
         if (!isAllowedToCancel()) {
-            cannotCancelDeliveredPurchaseOrder(cmd);
+            throw cannotCancelDeliveredPurchaseOrder(cmd);
         }
         final List<Order> orderList = getState().getOrderList();
         final PurchaseOrderCanceled poCanceledEvent = createPOCanceledEvent(cmd, orderList);

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejections.java
@@ -79,9 +79,9 @@ class PurchaseOrderAggregateRejections {
         checkNotNull(cmd);
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final UserId userId = cmd.getWhoMarksAsDelivered();
-        final CannotMarkPurchaseOrderAsDelivered cannotMarkPurchaseOrderAsDelivered =
+        final CannotMarkPurchaseOrderAsDelivered cannotMarkPOAsDelivered =
                 new CannotMarkPurchaseOrderAsDelivered(purchaseOrderId, userId, getCurrentTime());
-        throw cannotMarkPurchaseOrderAsDelivered;
+        throw cannotMarkPOAsDelivered;
     }
 
     /**
@@ -97,9 +97,9 @@ class PurchaseOrderAggregateRejections {
         checkNotNull(cmd);
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final UserId userId = cmd.getUserId();
-        final CannotCancelDeliveredPurchaseOrder cannotCancelDeliveredPurchaseOrder =
+        final CannotCancelDeliveredPurchaseOrder cannotCancelDeliveredPO =
                 new CannotCancelDeliveredPurchaseOrder(purchaseOrderId, userId, getCurrentTime());
-        throw cannotCancelDeliveredPurchaseOrder;
+        throw cannotCancelDeliveredPO;
     }
 
     /**
@@ -115,10 +115,10 @@ class PurchaseOrderAggregateRejections {
         checkNotNull(cmd);
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final UserId userId = cmd.getUserId();
-        final CannotOverruleValidationOfNotInvalidPO cannotOverruleValidationOfNotInvalidPO =
+        final CannotOverruleValidationOfNotInvalidPO cannotOverruleValidation =
                 new CannotOverruleValidationOfNotInvalidPO(purchaseOrderId,
                                                            userId,
                                                            getCurrentTime());
-        throw cannotOverruleValidationOfNotInvalidPO;
+        throw cannotOverruleValidation;
     }
 }

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejections.java
@@ -24,7 +24,6 @@ import io.spine.time.LocalDate;
 import javaclasses.mealorder.PurchaseOrderId;
 import javaclasses.mealorder.UserId;
 import javaclasses.mealorder.VendorId;
-import javaclasses.mealorder.c.po.PurchaseOrderAggregate;
 import javaclasses.mealorder.c.command.CancelPurchaseOrder;
 import javaclasses.mealorder.c.command.CreatePurchaseOrder;
 import javaclasses.mealorder.c.command.MarkPurchaseOrderAsDelivered;
@@ -38,11 +37,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.time.Time.getCurrentTime;
 
 /**
- * Utility class for working with {@link PurchaseOrderAggregate} rejection.
+ * Utility class for working with {@link PurchaseOrderAggregateRejections}.
  *
  * @author Yegor Udovchenko
  */
-public class PurchaseOrderAggregateRejections {
+class PurchaseOrderAggregateRejections {
 
     /** Prevents instantiation of this utility class. */
     private PurchaseOrderAggregateRejections() {
@@ -53,16 +52,18 @@ public class PurchaseOrderAggregateRejections {
      * according to the passed parameters.
      *
      * @param cmd the {@code CreatePurchaseOrder} command which thrown the rejection
-     * @throws CannotCreatePurchaseOrder the rejection to throw
+     * @throws CannotCreatePurchaseOrder if the {@code CreatePurchaseOrder} command is invalid
      */
-    public static void throwCannotCreatePurchaseOrder(CreatePurchaseOrder cmd)
+    static void cannotCreatePurchaseOrder(CreatePurchaseOrder cmd)
             throws CannotCreatePurchaseOrder {
         checkNotNull(cmd);
         final VendorId vendorId = cmd.getId()
                                      .getVendorId();
         final LocalDate poDate = cmd.getId()
                                     .getPoDate();
-        throw new CannotCreatePurchaseOrder(vendorId, poDate, getCurrentTime());
+        final CannotCreatePurchaseOrder cannotCreatePurchaseOrder =
+                new CannotCreatePurchaseOrder(vendorId, poDate, getCurrentTime());
+        throw cannotCreatePurchaseOrder;
     }
 
     /**
@@ -70,15 +71,17 @@ public class PurchaseOrderAggregateRejections {
      * according to the passed parameters.
      *
      * @param cmd the {@code MarkPurchaseOrderAsDelivered} command which thrown the rejection
-     * @throws CannotMarkPurchaseOrderAsDelivered the rejection to throw
+     * @throws CannotMarkPurchaseOrderAsDelivered if the purchase order is not allowed to
+     *                                            mark as delivered
      */
-    public static void throwCannotMarkPurchaseOrderAsDelivered(
-            MarkPurchaseOrderAsDelivered cmd) throws CannotMarkPurchaseOrderAsDelivered {
+    static void cannotMarkPurchaseOrderAsDelivered(MarkPurchaseOrderAsDelivered cmd)
+            throws CannotMarkPurchaseOrderAsDelivered {
         checkNotNull(cmd);
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final UserId userId = cmd.getWhoMarksAsDelivered();
-        throw new CannotMarkPurchaseOrderAsDelivered(purchaseOrderId, userId,
-                                                     getCurrentTime());
+        final CannotMarkPurchaseOrderAsDelivered cannotMarkPurchaseOrderAsDelivered =
+                new CannotMarkPurchaseOrderAsDelivered(purchaseOrderId, userId, getCurrentTime());
+        throw cannotMarkPurchaseOrderAsDelivered;
     }
 
     /**
@@ -86,14 +89,17 @@ public class PurchaseOrderAggregateRejections {
      * according to the passed parameters.
      *
      * @param cmd the {@code CancelPurchaseOrder} command which thrown the rejection
-     * @throws CannotCancelDeliveredPurchaseOrder the rejection to throw
+     * @throws CannotCancelDeliveredPurchaseOrder upon an attempt to mark delivered purchase
+     *                                            order as canceled
      */
-    public static void throwCannotCancelDeliveredPurchaseOrder(
-            CancelPurchaseOrder cmd) throws CannotCancelDeliveredPurchaseOrder {
+    static void cannotCancelDeliveredPurchaseOrder(CancelPurchaseOrder cmd)
+            throws CannotCancelDeliveredPurchaseOrder {
         checkNotNull(cmd);
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final UserId userId = cmd.getUserId();
-        throw new CannotCancelDeliveredPurchaseOrder(purchaseOrderId, userId, getCurrentTime());
+        final CannotCancelDeliveredPurchaseOrder cannotCancelDeliveredPurchaseOrder =
+                new CannotCancelDeliveredPurchaseOrder(purchaseOrderId, userId, getCurrentTime());
+        throw cannotCancelDeliveredPurchaseOrder;
     }
 
     /**
@@ -101,13 +107,18 @@ public class PurchaseOrderAggregateRejections {
      * according to the passed parameters.
      *
      * @param cmd the {@code CancelPurchaseOrder} command which thrown the rejection
-     * @throws CannotOverruleValidationOfNotInvalidPO the rejection to throw
+     * @throws CannotOverruleValidationOfNotInvalidPO upon an attempt to overrule validation of
+     *                                                not invalid purchase order
      */
-    public static void throwCannotOverruleValidationOfNotInvalidPO(
-            MarkPurchaseOrderAsValid cmd) throws CannotOverruleValidationOfNotInvalidPO {
+    static void cannotOverruleValidationOfNotInvalidPO(MarkPurchaseOrderAsValid cmd)
+            throws CannotOverruleValidationOfNotInvalidPO {
         checkNotNull(cmd);
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final UserId userId = cmd.getUserId();
-        throw new CannotOverruleValidationOfNotInvalidPO(purchaseOrderId, userId, getCurrentTime());
+        final CannotOverruleValidationOfNotInvalidPO cannotOverruleValidationOfNotInvalidPO =
+                new CannotOverruleValidationOfNotInvalidPO(purchaseOrderId,
+                                                           userId,
+                                                           getCurrentTime());
+        throw cannotOverruleValidationOfNotInvalidPO;
     }
 }

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejections.java
@@ -54,7 +54,7 @@ class PurchaseOrderAggregateRejections {
      * @param cmd the {@code CreatePurchaseOrder} command which thrown the rejection
      * @throws CannotCreatePurchaseOrder if the {@code CreatePurchaseOrder} command is invalid
      */
-    static void cannotCreatePurchaseOrder(CreatePurchaseOrder cmd)
+    static CannotCreatePurchaseOrder cannotCreatePurchaseOrder(CreatePurchaseOrder cmd)
             throws CannotCreatePurchaseOrder {
         checkNotNull(cmd);
         final VendorId vendorId = cmd.getId()
@@ -74,8 +74,8 @@ class PurchaseOrderAggregateRejections {
      * @throws CannotMarkPurchaseOrderAsDelivered if the purchase order is not allowed to
      *                                            mark as delivered
      */
-    static void cannotMarkPurchaseOrderAsDelivered(MarkPurchaseOrderAsDelivered cmd)
-            throws CannotMarkPurchaseOrderAsDelivered {
+    static CannotMarkPurchaseOrderAsDelivered cannotMarkPurchaseOrderAsDelivered(
+            MarkPurchaseOrderAsDelivered cmd) throws CannotMarkPurchaseOrderAsDelivered {
         checkNotNull(cmd);
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final UserId userId = cmd.getWhoMarksAsDelivered();
@@ -92,8 +92,8 @@ class PurchaseOrderAggregateRejections {
      * @throws CannotCancelDeliveredPurchaseOrder upon an attempt to mark delivered purchase
      *                                            order as canceled
      */
-    static void cannotCancelDeliveredPurchaseOrder(CancelPurchaseOrder cmd)
-            throws CannotCancelDeliveredPurchaseOrder {
+    static CannotCancelDeliveredPurchaseOrder cannotCancelDeliveredPurchaseOrder(
+            CancelPurchaseOrder cmd) throws CannotCancelDeliveredPurchaseOrder {
         checkNotNull(cmd);
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final UserId userId = cmd.getUserId();
@@ -110,8 +110,8 @@ class PurchaseOrderAggregateRejections {
      * @throws CannotOverruleValidationOfNotInvalidPO upon an attempt to overrule validation of
      *                                                not invalid purchase order
      */
-    static void cannotOverruleValidationOfNotInvalidPO(MarkPurchaseOrderAsValid cmd)
-            throws CannotOverruleValidationOfNotInvalidPO {
+    static CannotOverruleValidationOfNotInvalidPO cannotOverruleValidationOfNotInvalidPO(
+            MarkPurchaseOrderAsValid cmd) throws CannotOverruleValidationOfNotInvalidPO {
         checkNotNull(cmd);
         final PurchaseOrderId purchaseOrderId = cmd.getId();
         final UserId userId = cmd.getUserId();

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderRepository.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrderRepository.java
@@ -22,7 +22,6 @@ package javaclasses.mealorder.c.po;
 
 import io.spine.server.aggregate.AggregateRepository;
 import javaclasses.mealorder.PurchaseOrderId;
-import javaclasses.mealorder.c.po.PurchaseOrderAggregate;
 
 /**
  * Repository for the {@link PurchaseOrderAggregate}.

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
@@ -38,6 +38,7 @@ import static javaclasses.mealorder.OrderStatus.ORDER_ACTIVE;
  *
  * @author Yegor Udovchenko
  */
+@SuppressWarnings({"TypeMayBeWeakened", "SimplifiableIfStatement"})
 class PurchaseOrders {
     /**
      * {@code MAX_SINGLE_DISH_COUNT} is the max number of equal dishes in

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
@@ -234,7 +234,7 @@ class PurchaseOrders {
      * @param orders list of orders which were canceled
      * @return {@code PurchaseOrderCanceled} event instance
      */
-    @SuppressWarnings("all") /* To not use `default` switch branch*/
+    @SuppressWarnings("incomplete-switch") /* To not use `default` switch branch*/
     static PurchaseOrderCanceled createPOCanceledEvent(CancelPurchaseOrder cmd,
                                                        List<Order> orders) {
         final PurchaseOrderId purchaseOrderId = cmd.getId();

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
@@ -234,7 +234,7 @@ class PurchaseOrders {
      * @param orders list of orders which were canceled
      * @return {@code PurchaseOrderCanceled} event instance
      */
-    @SuppressWarnings("incomplete-switch") /* To not use `default` switch branch*/
+    @SuppressWarnings("all") /* To not use `default` switch branch*/
     static PurchaseOrderCanceled createPOCanceledEvent(CancelPurchaseOrder cmd,
                                                        List<Order> orders) {
         final PurchaseOrderId purchaseOrderId = cmd.getId();

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
@@ -39,9 +39,9 @@ import static javaclasses.mealorder.OrderStatus.ORDER_ACTIVE;
  * @author Yegor Udovchenko
  */
 @SuppressWarnings("TypeMayBeWeakened" /* Private methods of this class should
-                                           not use parameters weakened to `ObjectOrBuilder` classes.
-                                           Those methods are used for validation and not for
-                                           construction.*/)
+                                         not use parameters weakened to `ObjectOrBuilder` classes.
+                                         Those methods are used for validation and not for
+                                         construction.*/)
 class PurchaseOrders {
     /**
      * {@code MAX_SINGLE_DISH_COUNT} is the max number of equal dishes in

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
@@ -38,7 +38,10 @@ import static javaclasses.mealorder.OrderStatus.ORDER_ACTIVE;
  *
  * @author Yegor Udovchenko
  */
-@SuppressWarnings({"TypeMayBeWeakened", "SimplifiableIfStatement"})
+@SuppressWarnings("TypeMayBeWeakened" /* Private methods of this class should
+                                           not use parameters weakened to `ObjectOrBuilder` classes.
+                                           Those methods are used for validation and not for
+                                           construction.*/)
 class PurchaseOrders {
     /**
      * {@code MAX_SINGLE_DISH_COUNT} is the max number of equal dishes in
@@ -104,14 +107,13 @@ class PurchaseOrders {
         return result;
     }
 
+    @SuppressWarnings("OverlyComplexBooleanExpression")
     private static boolean doesOrderFitToPO(PurchaseOrderId purchaseOrderId, Order order) {
         final VendorId purchaseOrderVendorId = purchaseOrderId.getVendorId();
         final LocalDate purchaseOrderDate = purchaseOrderId.getPoDate();
 
-        if (!(checkOrderIsActive(order) && checkOrderingDatesMatch(order, purchaseOrderDate))) {
-            return false;
-        }
-        return checkOrderNotEmpty(order) && checkVendorsMatch(order, purchaseOrderVendorId);
+        return (checkOrderIsActive(order) && checkOrderingDatesMatch(order, purchaseOrderDate)) &&
+                checkOrderNotEmpty(order) && checkVendorsMatch(order, purchaseOrderVendorId);
     }
 
     private static boolean isOrderValid(Order order) {

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
@@ -20,18 +20,36 @@
 
 package javaclasses.mealorder.c.po;
 
+import io.spine.net.EmailAddress;
 import io.spine.time.LocalDate;
 import javaclasses.mealorder.Order;
 import javaclasses.mealorder.PurchaseOrder;
 import javaclasses.mealorder.PurchaseOrderId;
+import javaclasses.mealorder.PurchaseOrderStatus;
+import javaclasses.mealorder.UserId;
 import javaclasses.mealorder.VendorId;
+import javaclasses.mealorder.c.command.CancelPurchaseOrder;
 import javaclasses.mealorder.c.command.CreatePurchaseOrder;
+import javaclasses.mealorder.c.command.MarkPurchaseOrderAsDelivered;
+import javaclasses.mealorder.c.command.MarkPurchaseOrderAsValid;
+import javaclasses.mealorder.c.event.PurchaseOrderCanceled;
+import javaclasses.mealorder.c.event.PurchaseOrderCreated;
+import javaclasses.mealorder.c.event.PurchaseOrderDelivered;
+import javaclasses.mealorder.c.event.PurchaseOrderSent;
+import javaclasses.mealorder.c.event.PurchaseOrderValidationFailed;
+import javaclasses.mealorder.c.event.PurchaseOrderValidationOverruled;
+import javaclasses.mealorder.c.event.PurchaseOrderValidationPassed;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.time.Time.getCurrentTime;
 import static javaclasses.mealorder.OrderStatus.ORDER_ACTIVE;
+import static javaclasses.mealorder.PurchaseOrderStatus.DELIVERED;
+import static javaclasses.mealorder.PurchaseOrderStatus.INVALID;
+import static javaclasses.mealorder.PurchaseOrderStatus.SENT;
+import static javaclasses.mealorder.PurchaseOrderStatus.VALID;
 
 /**
  * The utility class to manage the process of creation of a {@link PurchaseOrder} instance.
@@ -94,7 +112,7 @@ class PurchaseOrders {
     }
 
     /**
-     * Searches for orders which contain more than {@code MAX_SINGLE_DISH_COUNT}
+     * Checks order list for those which contain more than {@code MAX_SINGLE_DISH_COUNT}
      * equal dishes.
      *
      * @param orders the list to check
@@ -107,12 +125,212 @@ class PurchaseOrders {
         return result;
     }
 
+    /**
+     * Creates {@code PurchaseOrderCreated} instance.
+     *
+     * @param cmd the command which fired an event
+     * @return {@code PurchaseOrderCreated} event instance
+     */
+    static PurchaseOrderCreated createPOCreatedEvent(CreatePurchaseOrder cmd) {
+        final PurchaseOrderId id = cmd.getId();
+        final UserId whoCreates = cmd.getWhoCreates();
+        final List<Order> orderList = cmd.getOrderList();
+        final PurchaseOrderCreated result = PurchaseOrderCreated.newBuilder()
+                                                                .setId(id)
+                                                                .setWhoCreated(whoCreates)
+                                                                .setWhenCreated(getCurrentTime())
+                                                                .addAllOrder(orderList)
+                                                                .build();
+        return result;
+    }
+
+    /**
+     * Creates {@code PurchaseOrderValidationFailed} instance.
+     *
+     * @param cmd the command which fired an event
+     * @param invalidOrders list of orders which validation has failed
+     * @return {@code PurchaseOrderValidationFailed} event instance
+     */
+    static PurchaseOrderValidationFailed createPOValidationFailedEvent(CreatePurchaseOrder cmd,
+                                                                       List<Order> invalidOrders) {
+        final PurchaseOrderId id = cmd.getId();
+        final PurchaseOrderValidationFailed result = PurchaseOrderValidationFailed
+                .newBuilder()
+                .setId(id)
+                .addAllFailureOrder(invalidOrders)
+                .setWhenFailed(getCurrentTime())
+                .build();
+
+        return result;
+    }
+
+    /**
+     * Creates {@code PurchaseOrderValidationPassed} instance.
+     *
+     * @param cmd the command which fired an event
+     * @return {@code PurchaseOrderValidationPassed} event instance
+     */
+    static PurchaseOrderValidationPassed createPOValidationPassedEvent(CreatePurchaseOrder cmd) {
+        final PurchaseOrderId id = cmd.getId();
+        final PurchaseOrderValidationPassed result = PurchaseOrderValidationPassed
+                .newBuilder()
+                .setId(id)
+                .setWhenPassed(getCurrentTime())
+                .build();
+
+        return result;
+    }
+
+    /**
+     * Creates {@code PurchaseOrderValidationOverruled} instance.
+     *
+     * @param cmd the command which fired an event
+     * @return {@code PurchaseOrderValidationOverruled} event instance
+     */
+    static PurchaseOrderValidationOverruled createPOValidationOverruledEvent(
+            MarkPurchaseOrderAsValid cmd) {
+        final PurchaseOrderId id = cmd.getId();
+        final UserId userId = cmd.getUserId();
+        final String reason = cmd.getReason();
+        final PurchaseOrderValidationOverruled result = PurchaseOrderValidationOverruled
+                .newBuilder()
+                .setId(id)
+                .setWhoOverruled(userId)
+                .setWhenOverruled(getCurrentTime())
+                .setReason(reason)
+                .build();
+
+        return result;
+    }
+
+    /**
+     * Creates {@code PurchaseOrderDelivered} instance.
+     *
+     * @param cmd the command which fired an event
+     * @return {@code PurchaseOrderDelivered} event instance
+     */
+    static PurchaseOrderDelivered createPOMarkedAsDeliveredEvent(MarkPurchaseOrderAsDelivered cmd) {
+        final PurchaseOrderId id = cmd.getId();
+        final UserId whoMarksAsDelivered = cmd.getWhoMarksAsDelivered();
+        final PurchaseOrderDelivered result = PurchaseOrderDelivered
+                .newBuilder()
+                .setId(id)
+                .setWhoMarkedAsDelivered(whoMarksAsDelivered)
+                .setWhenDelievered(getCurrentTime())
+                .build();
+
+        return result;
+    }
+
+    /**
+     * Creates {@code PurchaseOrderCanceled} instance.
+     *
+     * @param cmd the command which fired an event
+     * @param orders list of orders which were canceled
+     * @return {@code PurchaseOrderCanceled} event instance
+     */
+    static PurchaseOrderCanceled createPOCanceledEvent(CancelPurchaseOrder cmd,
+                                                       List<Order> orders) {
+        final PurchaseOrderId purchaseOrderId = cmd.getId();
+        final UserId userId = cmd.getUserId();
+        final PurchaseOrderCanceled.Builder builder = PurchaseOrderCanceled
+                .newBuilder()
+                .setId(purchaseOrderId)
+                .setUserId(userId)
+                .addAllOrder(orders)
+                .setWhenCanceled(getCurrentTime());
+
+        switch (cmd.getReasonCase()) {
+            case INVALID:
+                final boolean value = cmd.getInvalid();
+                builder.setInvalid(value);
+                break;
+            case CUSTOM_REASON:
+                final String customReason = cmd.getCustomReason();
+                builder.setCustomReason(customReason);
+                break;
+            case REASON_NOT_SET:
+                builder.setCustomReason("Reason not set.");
+                break;
+        }
+        return builder.build();
+    }
+
+    /**
+     * Creates {@code PurchaseOrderSent} instance.
+     *
+     * @param purchaseOrder the purchase order to send
+     * @param senderEmail the sender email address
+     * @param vendorEmail the vendor email address
+     * @return {@code PurchaseOrderSent} event instance
+     */
+    static PurchaseOrderSent createPOSentEvent(PurchaseOrder purchaseOrder,
+                                               EmailAddress senderEmail,
+                                               EmailAddress vendorEmail) {
+        final PurchaseOrderSent result = PurchaseOrderSent.newBuilder()
+                                                          .setPurchaseOrder(purchaseOrder)
+                                                          .setSenderEmail(senderEmail)
+                                                          .setVendorEmail(vendorEmail)
+                                                          .build();
+        return result;
+    }
+
+    /**
+     * Creates {@code PurchaseOrder} instance.
+     *
+     * @param cmd the command to get {@code PurchaseOrder} state from
+     * @return {@code PurchaseOrder} the created instance
+     */
+    static PurchaseOrder createPurchaseOrderInstance(CreatePurchaseOrder cmd) {
+        final PurchaseOrderId id = cmd.getId();
+        final List<Order> orderList = cmd.getOrderList();
+        final PurchaseOrder result = PurchaseOrder.newBuilder()
+                                                  .setId(id)
+                                                  .setStatus(VALID)
+                                                  .addAllOrder(orderList)
+                                                  .build();
+        return result;
+    }
+
+    /**
+     * Check {@code status} value for availability to transit to
+     * {@code VALID} state.
+     *
+     * @param status value to check
+     * @return {@code true} if transition is allowed
+     */
+    static boolean isAllowedToMarkAsValid(PurchaseOrderStatus status) {
+        return status == INVALID;
+    }
+
+    /**
+     * Check {@code status} value for availability to transit to
+     * {@code DELIVERED} state.
+     *
+     * @param status value to check
+     * @return {@code true} if transition is allowed
+     */
+    static boolean isAllowedToMarkAsDelivered(PurchaseOrderStatus status) {
+        return status == SENT;
+    }
+
+    /**
+     * Check {@code status} value for availability to transit to
+     * {@code CANCEL} state.
+     *
+     * @param status value to check
+     * @return {@code true} if transition is allowed
+     */
+    static boolean isAllowedToCancel(PurchaseOrderStatus status) {
+        return status != DELIVERED;
+    }
+
     @SuppressWarnings("OverlyComplexBooleanExpression")
     private static boolean doesOrderFitToPO(PurchaseOrderId purchaseOrderId, Order order) {
         final VendorId purchaseOrderVendorId = purchaseOrderId.getVendorId();
         final LocalDate purchaseOrderDate = purchaseOrderId.getPoDate();
 
-        return (checkOrderIsActive(order) && checkOrderingDatesMatch(order, purchaseOrderDate)) &&
+        return checkOrderIsActive(order) && checkOrderingDatesMatch(order, purchaseOrderDate) &&
                 checkOrderNotEmpty(order) && checkVendorsMatch(order, purchaseOrderVendorId);
     }
 

--- a/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
+++ b/api-java/src/main/java/javaclasses/mealorder/c/po/PurchaseOrders.java
@@ -52,7 +52,12 @@ import static javaclasses.mealorder.PurchaseOrderStatus.SENT;
 import static javaclasses.mealorder.PurchaseOrderStatus.VALID;
 
 /**
- * The utility class to manage the process of creation of a {@link PurchaseOrder} instance.
+ * The utility class to manage the process of creation and modification
+ * of a {@link PurchaseOrder} instance.
+ *
+ * <p> Contains methods for {@code CreatePurchaseOrder} command validation,
+ * methods for creation event instances for {@code PurchaseOrderAggregate},
+ * methods for validation of purchase order status transitions.
  *
  * @author Yegor Udovchenko
  */
@@ -147,7 +152,7 @@ class PurchaseOrders {
     /**
      * Creates {@code PurchaseOrderValidationFailed} instance.
      *
-     * @param cmd the command which fired an event
+     * @param cmd           the command which fired an event
      * @param invalidOrders list of orders which validation has failed
      * @return {@code PurchaseOrderValidationFailed} event instance
      */
@@ -225,10 +230,11 @@ class PurchaseOrders {
     /**
      * Creates {@code PurchaseOrderCanceled} instance.
      *
-     * @param cmd the command which fired an event
+     * @param cmd    the command which fired an event
      * @param orders list of orders which were canceled
      * @return {@code PurchaseOrderCanceled} event instance
      */
+    @SuppressWarnings("all") /* To not use `default` switch branch*/
     static PurchaseOrderCanceled createPOCanceledEvent(CancelPurchaseOrder cmd,
                                                        List<Order> orders) {
         final PurchaseOrderId purchaseOrderId = cmd.getId();
@@ -260,8 +266,8 @@ class PurchaseOrders {
      * Creates {@code PurchaseOrderSent} instance.
      *
      * @param purchaseOrder the purchase order to send
-     * @param senderEmail the sender email address
-     * @param vendorEmail the vendor email address
+     * @param senderEmail   the sender email address
+     * @param vendorEmail   the vendor email address
      * @return {@code PurchaseOrderSent} event instance
      */
     static PurchaseOrderSent createPOSentEvent(PurchaseOrder purchaseOrder,

--- a/api-java/src/test/java/javaclasses/mealorder/ServiceFactoryTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/ServiceFactoryTest.java
@@ -45,7 +45,7 @@ class ServiceFactoryTest {
 
     @Test
     @DisplayName("return mock instance in test mode")
-    void returnsInTest() {
+    void returnsInstanceInTest() {
         ServiceFactory.setPoSenderInstance(mock(PurchaseOrderSender.class));
         assertThat(ServiceFactory.getPurchaseOrderSender()
                                  .getClass(), instanceOf(Class.class));
@@ -53,7 +53,7 @@ class ServiceFactoryTest {
 
     @Test
     @DisplayName("throw `IllegalStateException` upon an attempt " +
-            "to set Purchase Order instance in production")
+            "to set `PurchaseOrderSender` instance in production")
     void setPOSenderInstanceInProduction() {
         Environment.getInstance()
                    .setToProduction();

--- a/api-java/src/test/java/javaclasses/mealorder/c/po/CancelPurchaseOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/po/CancelPurchaseOrderTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static javaclasses.mealorder.PurchaseOrderStatus.CANCELED;
+import static javaclasses.mealorder.c.event.PurchaseOrderCanceled.ReasonCase.CUSTOM_REASON;
+import static javaclasses.mealorder.c.event.PurchaseOrderCanceled.ReasonCase.INVALID;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.cancelPOWithCustomReasonInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.cancelPOWithEmptyReasonInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.cancelPOWithInvalidReasonInstance;
@@ -53,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * @author Yegor Udovchenko
  */
-@DisplayName("CancelPurchaseOrder command should be interpreted by PurchaseOrderAggregate and")
+@DisplayName("`CancelPurchaseOrder` command should be interpreted by `PurchaseOrderAggregate` and")
 public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurchaseOrder> {
     @Override
     @BeforeEach
@@ -62,7 +64,7 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
     }
 
     @Test
-    @DisplayName("set the purchase order status to 'CANCELED'")
+    @DisplayName("set the purchase order status to `CANCELED`")
     void cancelPurchaseOrder() {
         dispatchCreatedCmd();
         final CancelPurchaseOrder cancelCmd = cancelPOWithCustomReasonInstance();
@@ -76,30 +78,37 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
     }
 
     @Nested
-    @DisplayName("produce PurchaseOrderCanceled event with")
+    @DisplayName("produce `PurchaseOrderCanceled` event with")
     class ProduceEventWithReasonsTests {
         @Test
-        @DisplayName("'CUSTOM' reason")
+        @DisplayName("`CUSTOM` reason")
         void producePOCanceledWithCustomReasonEvent() {
             dispatchCreatedCmd();
             final CancelPurchaseOrder cancelCmd = cancelPOWithCustomReasonInstance();
             final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                         envelopeOf(cancelCmd));
             final PurchaseOrderCanceled poCanceled = (PurchaseOrderCanceled) messageList.get(0);
+            final int messageListSize = messageList.size();
+            final PurchaseOrderId cmdId = poCanceled.getId();
+            final PurchaseOrderCanceled.ReasonCase reasonCase = poCanceled.getReasonCase();
+            final String expectedReason = cancelCmd.getCustomReason();
+            final String actualReason = poCanceled.getCustomReason();
+            final int orderCount = poCanceled.getOrderCount();
+            final PurchaseOrderId aggregateId = aggregate.getId();
+            final Class<? extends Message> eventClass = messageList.get(0)
+                                                                   .getClass();
 
-            assertNotNull(aggregate.getId());
-            assertEquals(1, messageList.size());
-            assertEquals(PurchaseOrderCanceled.class, messageList.get(0)
-                                                                 .getClass());
-            assertEquals(purchaseOrderId, poCanceled.getId());
-            assertEquals(PurchaseOrderCanceled.ReasonCase.CUSTOM_REASON,
-                         poCanceled.getReasonCase());
-            assertEquals(cancelCmd.getCustomReason(), poCanceled.getCustomReason());
-            assertEquals(1, poCanceled.getOrderCount());
+            assertNotNull(aggregateId);
+            assertEquals(1, messageListSize);
+            assertEquals(PurchaseOrderCanceled.class, eventClass);
+            assertEquals(purchaseOrderId, cmdId);
+            assertEquals(CUSTOM_REASON, reasonCase);
+            assertEquals(expectedReason, actualReason);
+            assertEquals(1, orderCount);
         }
 
         @Test
-        @DisplayName("'CUSTOM' reason for undefined reason")
+        @DisplayName("`CUSTOM` reason for undefined reason")
         void producePOCanceledWithCustomReasonFromUndefinedEvent() {
             dispatchCreatedCmd();
             final CancelPurchaseOrder cancelCmd = cancelPOWithEmptyReasonInstance();
@@ -107,19 +116,26 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
                                                                         envelopeOf(cancelCmd));
             final PurchaseOrderCanceled poCanceled = (PurchaseOrderCanceled) messageList.get(0);
 
-            assertNotNull(aggregate.getId());
-            assertEquals(1, messageList.size());
-            assertEquals(PurchaseOrderCanceled.class, messageList.get(0)
-                                                                 .getClass());
-            assertEquals(purchaseOrderId, poCanceled.getId());
-            assertEquals(PurchaseOrderCanceled.ReasonCase.CUSTOM_REASON,
-                         poCanceled.getReasonCase());
-            assertEquals("Reason not set.", poCanceled.getCustomReason());
-            assertEquals(1, poCanceled.getOrderCount());
+            final PurchaseOrderId aggregateId = aggregate.getId();
+            final PurchaseOrderCanceled.ReasonCase reasonCase = poCanceled.getReasonCase();
+            final String customReason = poCanceled.getCustomReason();
+            final int orderCount = poCanceled.getOrderCount();
+            final int messageListSize = messageList.size();
+            final PurchaseOrderId eventId = poCanceled.getId();
+            final Class<? extends Message> eventClass = messageList.get(0)
+                                                                   .getClass();
+
+            assertNotNull(aggregateId);
+            assertEquals(1, messageListSize);
+            assertEquals(PurchaseOrderCanceled.class, eventClass);
+            assertEquals(purchaseOrderId, eventId);
+            assertEquals(CUSTOM_REASON, reasonCase);
+            assertEquals("Reason not set.", customReason);
+            assertEquals(1, orderCount);
         }
 
         @Test
-        @DisplayName("'INVALID' reason")
+        @DisplayName("`INVALID` reason")
         void producePOCanceledWithInvalidReasonEvent() {
             dispatchCreatedCmd();
             final CancelPurchaseOrder cancelCmd = cancelPOWithInvalidReasonInstance();
@@ -127,20 +143,29 @@ public class CancelPurchaseOrderTest extends PurchaseOrderCommandTest<CancelPurc
                                                                         envelopeOf(cancelCmd));
             final PurchaseOrderCanceled poCanceled = (PurchaseOrderCanceled) messageList.get(0);
 
-            assertNotNull(aggregate.getId());
-            assertEquals(1, messageList.size());
-            assertEquals(PurchaseOrderCanceled.class, messageList.get(0)
-                                                                 .getClass());
-            assertEquals(purchaseOrderId, poCanceled.getId());
-            assertEquals(PurchaseOrderCanceled.ReasonCase.INVALID, poCanceled.getReasonCase());
-            assertEquals(cancelCmd.getInvalid(), poCanceled.getInvalid());
-            assertEquals(1, poCanceled.getOrderCount());
+            final PurchaseOrderId aggregateId = aggregate.getId();
+            final int messageListSize = messageList.size();
+            final Class<? extends Message> eventClass = messageList.get(0)
+                                                                   .getClass();
+            final PurchaseOrderId eventId = poCanceled.getId();
+            final PurchaseOrderCanceled.ReasonCase reasonCase = poCanceled.getReasonCase();
+            final boolean expectedInvalidValue = cancelCmd.getInvalid();
+            final boolean actualInvalidReason = poCanceled.getInvalid();
+            final int orderCount = poCanceled.getOrderCount();
+
+            assertNotNull(aggregateId);
+            assertEquals(1, messageListSize);
+            assertEquals(PurchaseOrderCanceled.class, eventClass);
+            assertEquals(purchaseOrderId, eventId);
+            assertEquals(INVALID, reasonCase);
+            assertEquals(expectedInvalidValue, actualInvalidReason);
+            assertEquals(1, orderCount);
         }
     }
 
     @Test
-    @DisplayName("throw CannotCancelDeliveredPurchaseOrder rejection " +
-            "upon an attempt to cancel delivered PO")
+    @DisplayName("throw `CannotCancelDeliveredPurchaseOrder` rejection " +
+            "upon an attempt to cancel delivered purchase order")
     void cannotCancelDeliveredPurchaseOrder() {
         dispatchCreatedCmd();
         dispatchDeliveredCmd();

--- a/api-java/src/test/java/javaclasses/mealorder/c/po/CreatePurchaseOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/po/CreatePurchaseOrderTest.java
@@ -43,6 +43,7 @@ import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchComma
 import static javaclasses.mealorder.PurchaseOrderStatus.SENT;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderWithDatesMismatchOrdersInstance;
+import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderWithEmptyListInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderWithEmptyOrdersInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderWithInvalidOrdersInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderWithNotActiveOrdersInstance;
@@ -193,6 +194,17 @@ public class CreatePurchaseOrderTest extends PurchaseOrderCommandTest<CreatePurc
         @DisplayName("upon an attempt to add an order from another date")
         void cannotCreatePurchaseOrderForOrdersFromAnotherDate() {
             final CreatePurchaseOrder invalidCmd = createPurchaseOrderWithDatesMismatchOrdersInstance();
+
+            final Throwable t = assertThrows(Throwable.class,
+                                             () -> dispatchCommand(aggregate,
+                                                                   envelopeOf(invalidCmd)));
+            assertThat(Throwables.getRootCause(t), instanceOf(CannotCreatePurchaseOrder.class));
+        }
+
+        @Test
+        @DisplayName("upon an attempt to add an empty order list")
+        void cannotCreatePurchaseOrderForEmptyOrderList() {
+            final CreatePurchaseOrder invalidCmd = createPurchaseOrderWithEmptyListInstance();
 
             final Throwable t = assertThrows(Throwable.class,
                                              () -> dispatchCommand(aggregate,

--- a/api-java/src/test/java/javaclasses/mealorder/c/po/CreatePurchaseOrderTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/po/CreatePurchaseOrderTest.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * @author Yegor Udovchenko
  */
-@DisplayName("CreatePurchaseOrder command should be interpreted by PurchaseOrderAggregate and")
+@DisplayName("`CreatePurchaseOrder` command should be interpreted by `PurchaseOrderAggregate` and")
 public class CreatePurchaseOrderTest extends PurchaseOrderCommandTest<CreatePurchaseOrder> {
     @Override
     @BeforeEach
@@ -85,61 +85,75 @@ public class CreatePurchaseOrderTest extends PurchaseOrderCommandTest<CreatePurc
     }
 
     @Test
-    @DisplayName("produce PurchaseOrderCreated, PurchaseOrderValidationPassed, " +
-            "PurchaseOrderSent events")
+    @DisplayName("produce `PurchaseOrderCreated`, `PurchaseOrderValidationPassed`, " +
+            "`PurchaseOrderSent` events")
     void produceCreatedValidationPassedAndSentEvent() {
         final CreatePurchaseOrder createPOcmd = createPurchaseOrderInstance();
         final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                     envelopeOf(createPOcmd));
         final PurchaseOrderCreated purchaseOrderCreated = (PurchaseOrderCreated) messageList.get(0);
-        final PurchaseOrderValidationPassed purchaseOrderValidationPassed =
+        final PurchaseOrderValidationPassed poValidationPassed =
                 (PurchaseOrderValidationPassed) messageList.get(1);
         final PurchaseOrderSent purchaseOrderSent = (PurchaseOrderSent) messageList.get(2);
+        final PurchaseOrderId aggregateId = aggregate.getId();
+        final int messageListSize = messageList.size();
+        final Class<? extends Message> messageClassAtZero = messageList.get(0)
+                                                                       .getClass();
+        final Class<? extends Message> messageClassAtOne = messageList.get(1)
+                                                                      .getClass();
+        final Class<? extends Message> messageClassAtTwo = messageList.get(2)
+                                                                      .getClass();
+        final PurchaseOrderId purchaseOrderCreatedId = purchaseOrderCreated.getId();
+        final PurchaseOrderId poValidationPassedId = poValidationPassed.getId();
+        final PurchaseOrderId sentId = purchaseOrderSent.getPurchaseOrder()
+                                                        .getId();
+        final List<Order> sentOrders = purchaseOrderSent.getPurchaseOrder()
+                                                        .getOrderList();
+        final List<Order> storedOrders = aggregate.getState()
+                                                  .getOrderList();
 
-        assertNotNull(aggregate.getId());
-        assertEquals(3, messageList.size());
-        assertEquals(PurchaseOrderCreated.class, messageList.get(0)
-                                                            .getClass());
-        assertEquals(PurchaseOrderValidationPassed.class, messageList.get(1)
-                                                                     .getClass());
-        assertEquals(PurchaseOrderSent.class, messageList.get(2)
-                                                         .getClass());
-        assertEquals(purchaseOrderId, purchaseOrderCreated.getId());
-        assertEquals(purchaseOrderId, purchaseOrderValidationPassed.getId());
-        assertEquals(purchaseOrderId, purchaseOrderSent.getPurchaseOrder()
-                                                       .getId());
-        assertEquals(purchaseOrderSent.getPurchaseOrder()
-                                      .getOrderList(), aggregate.getState()
-                                                                .getOrderList());
+        assertNotNull(aggregateId);
+        assertEquals(3, messageListSize);
+        assertEquals(PurchaseOrderCreated.class, messageClassAtZero);
+        assertEquals(PurchaseOrderValidationPassed.class, messageClassAtOne);
+        assertEquals(PurchaseOrderSent.class, messageClassAtTwo);
+        assertEquals(purchaseOrderId, purchaseOrderCreatedId);
+        assertEquals(purchaseOrderId, poValidationPassedId);
+        assertEquals(purchaseOrderId, sentId);
+        assertEquals(sentOrders, storedOrders);
     }
 
     @Test
-    @DisplayName("produce PurchaseOrderCreated and PurchaseOrderValidationFailed events")
+    @DisplayName("produce `PurchaseOrderCreated` and `PurchaseOrderValidationFailed` events")
     void produceCreatedAndValidationFailedEvent() {
         final CreatePurchaseOrder createPOcmd = createPurchaseOrderWithInvalidOrdersInstance();
         final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                     envelopeOf(createPOcmd));
 
-        assertNotNull(aggregate.getId());
-        assertEquals(3, messageList.size());
-        assertEquals(PurchaseOrderCreated.class, messageList.get(0)
-                                                            .getClass());
-        assertEquals(PurchaseOrderValidationFailed.class, messageList.get(1)
-                                                                     .getClass());
+        final PurchaseOrderId aggregateId = aggregate.getId();
+        final int messageListSize = messageList.size();
+        final Class<? extends Message> messageClassAtZero = messageList.get(0)
+                                                                       .getClass();
+        final Class<? extends Message> messageClassAtOne = messageList.get(1)
+                                                                      .getClass();
         final PurchaseOrderCreated purchaseOrderCreated = (PurchaseOrderCreated) messageList.get(0);
-        final PurchaseOrderValidationFailed purchaseOrderValidationFailed =
+        final PurchaseOrderValidationFailed poValidationFailed =
                 (PurchaseOrderValidationFailed) messageList.get(1);
         final PurchaseOrderId actualCreatedId = purchaseOrderCreated.getId();
-        final PurchaseOrderId actualFailedId = purchaseOrderValidationFailed.getId();
-        final int actualFailureOrderCount = purchaseOrderValidationFailed.getFailureOrderCount();
+        final PurchaseOrderId actualFailedId = poValidationFailed.getId();
+        final int actualFailureOrderCount = poValidationFailed.getFailureOrderCount();
 
+        assertNotNull(aggregateId);
+        assertEquals(3, messageListSize);
+        assertEquals(PurchaseOrderCreated.class, messageClassAtZero);
+        assertEquals(PurchaseOrderValidationFailed.class, messageClassAtOne);
         assertEquals(purchaseOrderId, actualCreatedId);
         assertEquals(purchaseOrderId, actualFailedId);
         assertEquals(1, actualFailureOrderCount);
     }
 
     @Nested
-    @DisplayName("throw CannotCreatePurchaseOrder rejection ")
+    @DisplayName("throw `CannotCreatePurchaseOrder` rejection ")
     class CannotCreatePurchaseOrderTests {
 
         @Test

--- a/api-java/src/test/java/javaclasses/mealorder/c/po/MarkPOAsDeliveredTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/po/MarkPOAsDeliveredTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * @author Yegor Udovchenko
  */
-@DisplayName("MarkPurchaseOrderAsDelivered command should be interpreted by PurchaseOrderAggregate and")
+@DisplayName("`MarkPurchaseOrderAsDelivered` command should be interpreted by `PurchaseOrderAggregate` and")
 public class MarkPOAsDeliveredTest extends PurchaseOrderCommandTest<MarkPurchaseOrderAsDelivered> {
     @Override
     @BeforeEach
@@ -57,7 +57,7 @@ public class MarkPOAsDeliveredTest extends PurchaseOrderCommandTest<MarkPurchase
     }
 
     @Test
-    @DisplayName("set the purchase order status to 'DELIVERED'")
+    @DisplayName("set the purchase order status to `DELIVERED`")
     void markAsDelivered() {
         dispatchCreatedCmd();
         final MarkPurchaseOrderAsDelivered markAsDeliveredCmd =
@@ -72,26 +72,29 @@ public class MarkPOAsDeliveredTest extends PurchaseOrderCommandTest<MarkPurchase
     }
 
     @Test
-    @DisplayName("produce PurchaseOrderDelivered event")
+    @DisplayName("produce `PurchaseOrderDelivered` event")
     void producePurchaseOrderDeliveredEvent() {
         dispatchCreatedCmd();
         final MarkPurchaseOrderAsDelivered markAsDeliveredCmd =
                 markPurchaseOrderAsDeliveredInstance();
         final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                     envelopeOf(markAsDeliveredCmd));
-        assertNotNull(aggregate.getId());
-        assertEquals(1, messageList.size());
-        assertEquals(PurchaseOrderDelivered.class, messageList.get(0)
-                                                              .getClass());
         final PurchaseOrderDelivered poDelivered = (PurchaseOrderDelivered) messageList.get(0);
+        final PurchaseOrderId aggregateId = aggregate.getId();
+        final int messageListSize = messageList.size();
+        final Class<? extends Message> messageAtZeroClass = messageList.get(0)
+                                                                       .getClass();
         final PurchaseOrderId actualId = poDelivered.getId();
 
+        assertNotNull(aggregateId);
+        assertEquals(1, messageListSize);
+        assertEquals(PurchaseOrderDelivered.class, messageAtZeroClass);
         assertEquals(purchaseOrderId, actualId);
     }
 
     @Test
-    @DisplayName("throw CannotMarkPurchaseOrderAsDelivered rejection " +
-            "upon an attempt to mark PO with not sent state as delivered")
+    @DisplayName("throw `CannotMarkPurchaseOrderAsDelivered` rejection " +
+            "upon an attempt to mark purchase order with not `SENT` state as delivered")
     void cannotMarkPurchaseOrderAsDelivered() {
         final MarkPurchaseOrderAsDelivered markAsDeliveredCmd =
                 markPurchaseOrderAsDeliveredInstance();

--- a/api-java/src/test/java/javaclasses/mealorder/c/po/MarkPOAsValidTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/po/MarkPOAsValidTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * @author Yegor Udovchenko
  */
-@DisplayName("MarkPurchaseOrderAsValid command should be interpreted by PurchaseOrderAggregate and")
+@DisplayName("`MarkPurchaseOrderAsValid` command should be interpreted by `PurchaseOrderAggregate` and")
 public class MarkPOAsValidTest extends PurchaseOrderCommandTest<MarkPurchaseOrderAsValid> {
     @Override
     @BeforeEach
@@ -58,7 +58,7 @@ public class MarkPOAsValidTest extends PurchaseOrderCommandTest<MarkPurchaseOrde
     }
 
     @Test
-    @DisplayName("set the purchase order status to 'SENT'")
+    @DisplayName("set the purchase order status to `SENT`")
     void markAsValid() {
         dispatchCreatedWithInvalidStateCmd();
         final MarkPurchaseOrderAsValid markAsValidCmd = markPurchaseOrderAsValidInstance();
@@ -72,19 +72,18 @@ public class MarkPOAsValidTest extends PurchaseOrderCommandTest<MarkPurchaseOrde
     }
 
     @Test
-    @DisplayName("produce PurchaseOrderValidationOverruled and event")
+    @DisplayName("produce `PurchaseOrderValidationOverruled` event")
     void producePairOFEvent() {
         dispatchCreatedWithInvalidStateCmd();
         final MarkPurchaseOrderAsValid markAsValidCmd = markPurchaseOrderAsValidInstance();
         final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                     envelopeOf(markAsValidCmd));
-
-        assertNotNull(aggregate.getId());
-        assertEquals(2, messageList.size());
-        assertEquals(PurchaseOrderValidationOverruled.class, messageList.get(0)
-                                                                        .getClass());
-        assertEquals(PurchaseOrderSent.class, messageList.get(1)
-                                                         .getClass());
+        final PurchaseOrderId aggregateId = aggregate.getId();
+        final int messageListSize = messageList.size();
+        final Class<? extends Message> messageClassAtZero = messageList.get(0)
+                                                                       .getClass();
+        final Class<? extends Message> messageClassAtOne = messageList.get(1)
+                                                                      .getClass();
         final PurchaseOrderValidationOverruled poValidationOverruled =
                 (PurchaseOrderValidationOverruled) messageList.get(0);
         final PurchaseOrderSent purchaseOrderSent = (PurchaseOrderSent) messageList.get(1);
@@ -92,13 +91,17 @@ public class MarkPOAsValidTest extends PurchaseOrderCommandTest<MarkPurchaseOrde
         final PurchaseOrderId sentActualId = purchaseOrderSent.getPurchaseOrder()
                                                               .getId();
 
+        assertNotNull(aggregateId);
+        assertEquals(2, messageListSize);
+        assertEquals(PurchaseOrderValidationOverruled.class, messageClassAtZero);
+        assertEquals(PurchaseOrderSent.class, messageClassAtOne);
         assertEquals(purchaseOrderId, overruledActualId);
         assertEquals(purchaseOrderId, sentActualId);
     }
 
     @Test
-    @DisplayName("throw CannotOverruleValidationOfNotInvalidPO rejection " +
-            "upon an attempt to mark PO with not invalid state")
+    @DisplayName("throw `CannotOverruleValidationOfNotInvalidPO` rejection " +
+            "upon an attempt to mark purchase order with not `INVALID` state")
     void cannotOverrulePurchaseOrderValidation() {
         final MarkPurchaseOrderAsValid markAsValidCmd = markPurchaseOrderAsValidInstance();
 

--- a/api-java/src/test/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejectionsTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejectionsTest.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * @author Yegor Udovchenko
  */
-@DisplayName("PurchaseOrderAggregateRejections should")
+@DisplayName("`PurchaseOrderAggregateRejections` should")
 class PurchaseOrderAggregateRejectionsTest {
 
     @Test
@@ -63,89 +63,95 @@ class PurchaseOrderAggregateRejectionsTest {
     }
 
     @Test
-    @DisplayName("throw CannotCreatePurchaseOrder rejection")
+    @DisplayName("throw `CannotCreatePurchaseOrder` rejection")
     void throwCannotCreatePurchaseOrderRejection() {
         final CreatePurchaseOrder cmd = createPurchaseOrderWithNotActiveOrdersInstance();
         final CannotCreatePurchaseOrder rejection = assertThrows(CannotCreatePurchaseOrder.class,
                                                                  () -> cannotCreatePurchaseOrder(
                                                                          cmd));
         final VendorId actualVendorId = rejection.getMessageThrown()
-                                           .getVendorId();
+                                                 .getVendorId();
         final LocalDate actualDate = rejection.getMessageThrown()
-                                        .getPurchaseOrderDate();
-        assertEquals(PURCHASE_ORDER_ID.getPoDate(), actualDate);
-        assertEquals(PURCHASE_ORDER_ID.getVendorId(), actualVendorId);
+                                              .getPurchaseOrderDate();
+        final LocalDate expectedDate = PURCHASE_ORDER_ID.getPoDate();
+        final VendorId expectedVendorId = PURCHASE_ORDER_ID.getVendorId();
+
+        assertEquals(expectedDate, actualDate);
+        assertEquals(expectedVendorId, actualVendorId);
     }
 
     @Test
-    @DisplayName("throw CannotMarkPurchaseOrderAsDelivered rejection")
+    @DisplayName("throw `CannotMarkPurchaseOrderAsDelivered` rejection")
     void throwCannotMarkPurchaseOrderAsDeliveredRejection() {
         final MarkPurchaseOrderAsDelivered cmd = markPurchaseOrderAsDeliveredInstance();
         final CannotMarkPurchaseOrderAsDelivered rejection =
                 assertThrows(CannotMarkPurchaseOrderAsDelivered.class,
                              () -> cannotMarkPurchaseOrderAsDelivered(cmd));
         final PurchaseOrderId actual = rejection.getMessageThrown()
-                                          .getPoId();
+                                                .getPoId();
         final UserId actualUser = rejection.getMessageThrown()
-                                     .getUserId();
+                                           .getUserId();
 
         assertEquals(PURCHASE_ORDER_ID, actual);
         assertEquals(USER_ID, actualUser);
     }
 
     @Test
-    @DisplayName("throw CannotCancelDeliveredPurchaseOrder rejection")
+    @DisplayName("throw `CannotCancelDeliveredPurchaseOrder` rejection")
     void throwCannotCancelDeliveredPurchaseOrderRejection() {
         final CancelPurchaseOrder cmd = cancelPOWithCustomReasonInstance();
         final CannotCancelDeliveredPurchaseOrder rejection =
                 assertThrows(CannotCancelDeliveredPurchaseOrder.class,
                              () -> cannotCancelDeliveredPurchaseOrder(cmd));
         final PurchaseOrderId actualId = rejection.getMessageThrown()
-                                            .getPoId();
+                                                  .getPoId();
         final UserId actualUser = rejection.getMessageThrown()
-                                     .getUserId();
+                                           .getUserId();
 
         assertEquals(PURCHASE_ORDER_ID, actualId);
         assertEquals(USER_ID, actualUser);
     }
 
     @Test
-    @DisplayName("throw CannotOverruleValidationOfNotInvalidPO rejection")
+    @DisplayName("throw `CannotOverruleValidationOfNotInvalidPO` rejection")
     void throwCannotOverruleValidationOfNotInvalidPORejection() {
         final MarkPurchaseOrderAsValid cmd = markPurchaseOrderAsValidInstance();
         final CannotOverruleValidationOfNotInvalidPO rejection =
                 assertThrows(CannotOverruleValidationOfNotInvalidPO.class,
                              () -> cannotOverruleValidationOfNotInvalidPO(cmd));
         final PurchaseOrderId actualId = rejection.getMessageThrown()
-                                            .getPoId();
+                                                  .getPoId();
         final UserId actualUser = rejection.getMessageThrown()
-                                     .getUserId();
+                                           .getUserId();
 
         assertEquals(PURCHASE_ORDER_ID, actualId);
         assertEquals(USER_ID, actualUser);
     }
 
     @Test
-    @DisplayName("don't throw CannotCreatePurchaseOrder rejection for empty command ")
+    @DisplayName("don't throw `CannotCreatePurchaseOrder` rejection for empty command ")
     void doNotThrowCannotCreatePurchaseOrderRejection() {
         assertThrows(NullPointerException.class, () -> cannotCreatePurchaseOrder(Tests.nullRef()));
     }
 
     @Test
-    @DisplayName("don't throw CannotMarkPurchaseOrderAsDelivered rejection for empty command ")
+    @DisplayName("don't throw `CannotMarkPurchaseOrderAsDelivered` rejection for empty command ")
     void doNotThrowCannotMarkPurchaseOrderAsDeliveredRejection() {
-        assertThrows(NullPointerException.class, () -> cannotMarkPurchaseOrderAsDelivered(Tests.nullRef()));
+        assertThrows(NullPointerException.class,
+                     () -> cannotMarkPurchaseOrderAsDelivered(Tests.nullRef()));
     }
 
     @Test
-    @DisplayName("don't throw CannotCancelDeliveredPurchaseOrder rejection for empty command ")
+    @DisplayName("don't throw `CannotCancelDeliveredPurchaseOrder` rejection for empty command ")
     void doNotThrowCannotCancelDeliveredPurchaseOrderRejection() {
-        assertThrows(NullPointerException.class, () -> cannotCancelDeliveredPurchaseOrder(Tests.nullRef()));
+        assertThrows(NullPointerException.class,
+                     () -> cannotCancelDeliveredPurchaseOrder(Tests.nullRef()));
     }
 
     @Test
-    @DisplayName("don't throw CannotOverruleValidationOfNotInvalidPO rejection for empty command ")
+    @DisplayName("don't throw `CannotOverruleValidationOfNotInvalidPO` rejection for empty command ")
     void doNotThrowCannotOverruleValidationOfNotInvalidPORejection() {
-        assertThrows(NullPointerException.class, () -> cannotOverruleValidationOfNotInvalidPO(Tests.nullRef()));
+        assertThrows(NullPointerException.class,
+                     () -> cannotOverruleValidationOfNotInvalidPO(Tests.nullRef()));
     }
 }

--- a/api-java/src/test/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejectionsTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/po/PurchaseOrderAggregateRejectionsTest.java
@@ -29,7 +29,6 @@ import javaclasses.mealorder.c.command.CancelPurchaseOrder;
 import javaclasses.mealorder.c.command.CreatePurchaseOrder;
 import javaclasses.mealorder.c.command.MarkPurchaseOrderAsDelivered;
 import javaclasses.mealorder.c.command.MarkPurchaseOrderAsValid;
-import javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections;
 import javaclasses.mealorder.c.rejection.CannotCancelDeliveredPurchaseOrder;
 import javaclasses.mealorder.c.rejection.CannotCreatePurchaseOrder;
 import javaclasses.mealorder.c.rejection.CannotMarkPurchaseOrderAsDelivered;
@@ -38,11 +37,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
-import static javaclasses.mealorder.c.BoundedContexts.createBoundedContext;
-import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.throwCannotCancelDeliveredPurchaseOrder;
-import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.throwCannotCreatePurchaseOrder;
-import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.throwCannotMarkPurchaseOrderAsDelivered;
-import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.throwCannotOverruleValidationOfNotInvalidPO;
+import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.cannotCancelDeliveredPurchaseOrder;
+import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.cannotCreatePurchaseOrder;
+import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.cannotMarkPurchaseOrderAsDelivered;
+import static javaclasses.mealorder.c.po.PurchaseOrderAggregateRejections.cannotOverruleValidationOfNotInvalidPO;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.cancelPOWithCustomReasonInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.createPurchaseOrderWithNotActiveOrdersInstance;
 import static javaclasses.mealorder.testdata.TestPurchaseOrderCommandFactory.markPurchaseOrderAsDeliveredInstance;
@@ -69,7 +67,7 @@ class PurchaseOrderAggregateRejectionsTest {
     void throwCannotCreatePurchaseOrderRejection() {
         final CreatePurchaseOrder cmd = createPurchaseOrderWithNotActiveOrdersInstance();
         final CannotCreatePurchaseOrder rejection = assertThrows(CannotCreatePurchaseOrder.class,
-                                                                 () -> throwCannotCreatePurchaseOrder(
+                                                                 () -> cannotCreatePurchaseOrder(
                                                                          cmd));
         final VendorId actualVendorId = rejection.getMessageThrown()
                                            .getVendorId();
@@ -85,7 +83,7 @@ class PurchaseOrderAggregateRejectionsTest {
         final MarkPurchaseOrderAsDelivered cmd = markPurchaseOrderAsDeliveredInstance();
         final CannotMarkPurchaseOrderAsDelivered rejection =
                 assertThrows(CannotMarkPurchaseOrderAsDelivered.class,
-                             () -> throwCannotMarkPurchaseOrderAsDelivered(cmd));
+                             () -> cannotMarkPurchaseOrderAsDelivered(cmd));
         final PurchaseOrderId actual = rejection.getMessageThrown()
                                           .getPoId();
         final UserId actualUser = rejection.getMessageThrown()
@@ -101,7 +99,7 @@ class PurchaseOrderAggregateRejectionsTest {
         final CancelPurchaseOrder cmd = cancelPOWithCustomReasonInstance();
         final CannotCancelDeliveredPurchaseOrder rejection =
                 assertThrows(CannotCancelDeliveredPurchaseOrder.class,
-                             () -> throwCannotCancelDeliveredPurchaseOrder(cmd));
+                             () -> cannotCancelDeliveredPurchaseOrder(cmd));
         final PurchaseOrderId actualId = rejection.getMessageThrown()
                                             .getPoId();
         final UserId actualUser = rejection.getMessageThrown()
@@ -117,7 +115,7 @@ class PurchaseOrderAggregateRejectionsTest {
         final MarkPurchaseOrderAsValid cmd = markPurchaseOrderAsValidInstance();
         final CannotOverruleValidationOfNotInvalidPO rejection =
                 assertThrows(CannotOverruleValidationOfNotInvalidPO.class,
-                             () -> throwCannotOverruleValidationOfNotInvalidPO(cmd));
+                             () -> cannotOverruleValidationOfNotInvalidPO(cmd));
         final PurchaseOrderId actualId = rejection.getMessageThrown()
                                             .getPoId();
         final UserId actualUser = rejection.getMessageThrown()
@@ -130,24 +128,24 @@ class PurchaseOrderAggregateRejectionsTest {
     @Test
     @DisplayName("don't throw CannotCreatePurchaseOrder rejection for empty command ")
     void doNotThrowCannotCreatePurchaseOrderRejection() {
-        assertThrows(NullPointerException.class, () -> throwCannotCreatePurchaseOrder(Tests.nullRef()));
+        assertThrows(NullPointerException.class, () -> cannotCreatePurchaseOrder(Tests.nullRef()));
     }
 
     @Test
     @DisplayName("don't throw CannotMarkPurchaseOrderAsDelivered rejection for empty command ")
     void doNotThrowCannotMarkPurchaseOrderAsDeliveredRejection() {
-        assertThrows(NullPointerException.class, () -> throwCannotMarkPurchaseOrderAsDelivered(Tests.nullRef()));
+        assertThrows(NullPointerException.class, () -> cannotMarkPurchaseOrderAsDelivered(Tests.nullRef()));
     }
 
     @Test
     @DisplayName("don't throw CannotCancelDeliveredPurchaseOrder rejection for empty command ")
     void doNotThrowCannotCancelDeliveredPurchaseOrderRejection() {
-        assertThrows(NullPointerException.class, () -> throwCannotCancelDeliveredPurchaseOrder(Tests.nullRef()));
+        assertThrows(NullPointerException.class, () -> cannotCancelDeliveredPurchaseOrder(Tests.nullRef()));
     }
 
     @Test
     @DisplayName("don't throw CannotOverruleValidationOfNotInvalidPO rejection for empty command ")
     void doNotThrowCannotOverruleValidationOfNotInvalidPORejection() {
-        assertThrows(NullPointerException.class, () -> throwCannotOverruleValidationOfNotInvalidPO(Tests.nullRef()));
+        assertThrows(NullPointerException.class, () -> cannotOverruleValidationOfNotInvalidPO(Tests.nullRef()));
     }
 }

--- a/api-java/src/test/java/javaclasses/mealorder/c/po/PurchaseOrderCommandTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/po/PurchaseOrderCommandTest.java
@@ -25,7 +25,6 @@ import io.spine.client.TestActorRequestFactory;
 import io.spine.core.CommandEnvelope;
 import io.spine.server.aggregate.AggregateCommandTest;
 import javaclasses.mealorder.PurchaseOrderId;
-import javaclasses.mealorder.c.po.PurchaseOrderAggregate;
 import javaclasses.mealorder.PurchaseOrderSender;
 import javaclasses.mealorder.ServiceFactory;
 
@@ -57,7 +56,8 @@ abstract class PurchaseOrderCommandTest<C extends Message>
     @Override
     protected PurchaseOrderAggregate createAggregate() {
         purchaseOrderId = createPurchaseOrderId();
-        final PurchaseOrderAggregate purchaseOrderAggregate = new PurchaseOrderAggregate(purchaseOrderId);
+        final PurchaseOrderAggregate purchaseOrderAggregate = new PurchaseOrderAggregate(
+                purchaseOrderId);
         return purchaseOrderAggregate;
     }
 
@@ -73,7 +73,7 @@ abstract class PurchaseOrderCommandTest<C extends Message>
                               .build();
     }
 
-    private void setSenderMock() {
+    private static void setSenderMock() {
         final PurchaseOrderSender purchaseOrderSenderMock = mock(PurchaseOrderSender.class);
         ServiceFactory.setPoSenderInstance(purchaseOrderSenderMock);
     }

--- a/api-java/src/test/java/javaclasses/mealorder/c/po/PurchaseOrdersTest.java
+++ b/api-java/src/test/java/javaclasses/mealorder/c/po/PurchaseOrdersTest.java
@@ -21,24 +21,19 @@
 package javaclasses.mealorder.c.po;
 
 import io.spine.test.Tests;
-import javaclasses.mealorder.c.command.CreatePurchaseOrder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
 
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 import static javaclasses.mealorder.c.po.PurchaseOrders.findInvalidOrders;
 import static javaclasses.mealorder.c.po.PurchaseOrders.hasInvalidOrders;
 import static javaclasses.mealorder.c.po.PurchaseOrders.isAllowedPurchaseOrderCreation;
-import static javaclasses.mealorder.testdata.TestValues.PURCHASE_ORDER_ID;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Yegor Udovchenko
  */
-@DisplayName("PurchaseOrders should")
+@DisplayName("`PurchaseOrders` should")
 class PurchaseOrdersTest {
 
     @Test
@@ -48,30 +43,20 @@ class PurchaseOrdersTest {
     }
 
     @Test
-    @DisplayName("return false for empty list of dishes")
-    void returnFalseForEmptyList() {
-        CreatePurchaseOrder createPurchaseOrder = CreatePurchaseOrder.newBuilder()
-                                                                     .setId(PURCHASE_ORDER_ID)
-                                                                     .addAllOrder(new ArrayList<>())
-                                                                     .build();
-        assertFalse(isAllowedPurchaseOrderCreation(createPurchaseOrder));
-    }
-
-    @Test
-    @DisplayName("don't check Purchase Order creation without a command")
+    @DisplayName("throw `NPE` when null command passed to check")
     void doNotCheckPurchaseOrderCreationWithoutCommand() {
         assertThrows(NullPointerException.class,
                      () -> isAllowedPurchaseOrderCreation(Tests.nullRef()));
     }
 
     @Test
-    @DisplayName("don't find invalid orders without orders")
+    @DisplayName("throw `NPE` for null order list passed to find invalid orders")
     void doNotFindInvalidOrdersWithoutOrders() {
         assertThrows(NullPointerException.class, () -> findInvalidOrders(Tests.nullRef()));
     }
 
     @Test
-    @DisplayName("don't check invalid orders without orders")
+    @DisplayName("throw `NPE` for null order list passed to check has invalid orders")
     void doNotCheckInvalidOrdersWithoutOrders() {
         assertThrows(NullPointerException.class, () -> hasInvalidOrders(Tests.nullRef()));
     }

--- a/testutil-api/src/main/java/javaclasses/mealorder/testdata/TestPurchaseOrderCommandFactory.java
+++ b/testutil-api/src/main/java/javaclasses/mealorder/testdata/TestPurchaseOrderCommandFactory.java
@@ -24,6 +24,7 @@ import io.spine.time.LocalDate;
 import javaclasses.mealorder.Dish;
 import javaclasses.mealorder.Order;
 import javaclasses.mealorder.OrderId;
+import javaclasses.mealorder.OrderStatus;
 import javaclasses.mealorder.PurchaseOrderId;
 import javaclasses.mealorder.VendorId;
 import javaclasses.mealorder.c.command.CancelPurchaseOrder;
@@ -72,13 +73,18 @@ public class TestPurchaseOrderCommandFactory {
      * @return the invalid {@code CreatePurchaseOrder} instance.
      */
     public static CreatePurchaseOrder createPurchaseOrderWithVendorMismatchInstance() {
-        return CreatePurchaseOrder.newBuilder(createPurchaseOrderInstance())
-                                  .setId(PurchaseOrderId.newBuilder(PURCHASE_ORDER_ID)
-                                                        .setVendorId(VendorId.newBuilder()
-                                                                             .setValue(
-                                                                                     "vendor:other")
-                                                                             .build()))
-                                  .build();
+        final CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
+
+        final VendorId invalidVendorId = VendorId.newBuilder()
+                                                 .setValue("vendor:other")
+                                                 .build();
+        final PurchaseOrderId invalidId = PurchaseOrderId.newBuilder(PURCHASE_ORDER_ID)
+                                                         .setVendorId(invalidVendorId)
+                                                         .build();
+        final CreatePurchaseOrder result = CreatePurchaseOrder.newBuilder(validCmd)
+                                                              .setId(invalidId)
+                                                              .build();
+        return result;
     }
 
     /**
@@ -90,10 +96,13 @@ public class TestPurchaseOrderCommandFactory {
     public static CreatePurchaseOrder createPurchaseOrderWithNotActiveOrdersInstance() {
         final CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
         final Order order = validCmd.getOrder(0);
-        return CreatePurchaseOrder.newBuilder(validCmd)
-                                  .addOrder(Order.newBuilder(order)
-                                                 .setStatus(ORDER_CANCELED))
-                                  .build();
+        final Order invalidOrder = Order.newBuilder(order)
+                                        .setStatus(ORDER_CANCELED)
+                                        .build();
+        final CreatePurchaseOrder result = CreatePurchaseOrder.newBuilder(validCmd)
+                                                              .addOrder(invalidOrder)
+                                                              .build();
+        return result;
     }
 
     /**
@@ -105,12 +114,16 @@ public class TestPurchaseOrderCommandFactory {
     public static CreatePurchaseOrder createPurchaseOrderWithEmptyOrdersInstance() {
         final CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
         final Order order = validCmd.getOrder(0);
-        return CreatePurchaseOrder.newBuilder(validCmd)
-                                  .addOrder(Order.newBuilder()
-                                                 .setStatus(order.getStatus())
-                                                 .setId(order.getId())
-                                                 .build())
-                                  .build();
+        final OrderStatus status = order.getStatus();
+        final OrderId id = order.getId();
+        final Order invalidOrder = Order.newBuilder()
+                                        .setStatus(status)
+                                        .setId(id)
+                                        .build();
+        final CreatePurchaseOrder result = CreatePurchaseOrder.newBuilder(validCmd)
+                                                              .addOrder(invalidOrder)
+                                                              .build();
+        return result;
     }
 
     /**
@@ -122,13 +135,31 @@ public class TestPurchaseOrderCommandFactory {
     public static CreatePurchaseOrder createPurchaseOrderWithDatesMismatchOrdersInstance() {
         final CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
         final Order order = validCmd.getOrder(0);
-        return CreatePurchaseOrder.newBuilder(validCmd)
-                                  .addOrder(Order.newBuilder(order)
-                                                 .setId(OrderId.newBuilder(order.getId())
-                                                               .setOrderDate(
-                                                                       LocalDate.getDefaultInstance()))
-                                                 .build())
-                                  .build();
+        final OrderId id = order.getId();
+        final OrderId.Builder invalidOrderId = OrderId.newBuilder(id)
+                                                      .setOrderDate(LocalDate.getDefaultInstance());
+        final Order invalidOrder = Order.newBuilder(order)
+                                        .setId(invalidOrderId)
+                                        .build();
+        final CreatePurchaseOrder result = CreatePurchaseOrder.newBuilder(validCmd)
+                                                              .addOrder(invalidOrder)
+                                                              .build();
+        return result;
+    }
+
+    /**
+     * Provides a pre-configured {@link CreatePurchaseOrder} instance
+     * with an order in the list which date is not consistent with PO date.
+     *
+     * @return the invalid {@code CreatePurchaseOrder} instance.
+     */
+    public static CreatePurchaseOrder createPurchaseOrderWithEmptyListInstance() {
+        final CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
+        final PurchaseOrderId id = validCmd.getId();
+        final CreatePurchaseOrder result = CreatePurchaseOrder.newBuilder()
+                                                              .setId(id)
+                                                              .build();
+        return result;
     }
 
     /**
@@ -142,15 +173,18 @@ public class TestPurchaseOrderCommandFactory {
         final CreatePurchaseOrder validCmd = createPurchaseOrderInstance();
         final Order order = validCmd.getOrder(0);
         final Dish dish = order.getDish(0);
+
         List<Dish> dishes = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
             dishes.add(dish);
         }
-        return CreatePurchaseOrder.newBuilder(validCmd)
-                                  .addOrder(Order.newBuilder(order)
-                                                 .addAllDish(dishes)
-                                                 .build())
-                                  .build();
+        final Order invalidOrder = Order.newBuilder(order)
+                                        .addAllDish(dishes)
+                                        .build();
+        final CreatePurchaseOrder result = CreatePurchaseOrder.newBuilder(validCmd)
+                                                              .addOrder(invalidOrder)
+                                                              .build();
+        return result;
     }
 
     /**
@@ -159,11 +193,12 @@ public class TestPurchaseOrderCommandFactory {
      * @return the {@code MarkPurchaseOrderAsValid} instance.
      */
     public static MarkPurchaseOrderAsValid markPurchaseOrderAsValidInstance() {
-        return MarkPurchaseOrderAsValid.newBuilder()
-                                       .setId(PURCHASE_ORDER_ID)
-                                       .setReason("Because I can.")
-                                       .setUserId(USER_ID)
-                                       .build();
+        final MarkPurchaseOrderAsValid result = MarkPurchaseOrderAsValid.newBuilder()
+                                                                        .setId(PURCHASE_ORDER_ID)
+                                                                        .setReason("Because I can.")
+                                                                        .setUserId(USER_ID)
+                                                                        .build();
+        return result;
     }
 
     /**
@@ -173,11 +208,12 @@ public class TestPurchaseOrderCommandFactory {
      * @return the {@code CancelPurchaseOrder} instance.
      */
     public static CancelPurchaseOrder cancelPOWithCustomReasonInstance() {
-        return CancelPurchaseOrder.newBuilder()
-                                  .setId(PURCHASE_ORDER_ID)
-                                  .setCustomReason("Because why not.")
-                                  .setUserId(USER_ID)
-                                  .build();
+        final CancelPurchaseOrder result = CancelPurchaseOrder.newBuilder()
+                                                              .setId(PURCHASE_ORDER_ID)
+                                                              .setCustomReason("Because why not.")
+                                                              .setUserId(USER_ID)
+                                                              .build();
+        return result;
     }
 
     /**
@@ -187,10 +223,11 @@ public class TestPurchaseOrderCommandFactory {
      * @return the {@code CancelPurchaseOrder} instance.
      */
     public static CancelPurchaseOrder cancelPOWithEmptyReasonInstance() {
-        return CancelPurchaseOrder.newBuilder()
-                                  .setId(PURCHASE_ORDER_ID)
-                                  .setUserId(USER_ID)
-                                  .build();
+        final CancelPurchaseOrder result = CancelPurchaseOrder.newBuilder()
+                                                              .setId(PURCHASE_ORDER_ID)
+                                                              .setUserId(USER_ID)
+                                                              .build();
+        return result;
     }
 
     /**
@@ -200,11 +237,12 @@ public class TestPurchaseOrderCommandFactory {
      * @return the {@code CancelPurchaseOrder} instance.
      */
     public static CancelPurchaseOrder cancelPOWithInvalidReasonInstance() {
-        return CancelPurchaseOrder.newBuilder()
-                                  .setId(PURCHASE_ORDER_ID)
-                                  .setInvalid(true)
-                                  .setUserId(USER_ID)
-                                  .build();
+        final CancelPurchaseOrder result = CancelPurchaseOrder.newBuilder()
+                                                              .setId(PURCHASE_ORDER_ID)
+                                                              .setInvalid(true)
+                                                              .setUserId(USER_ID)
+                                                              .build();
+        return result;
     }
 
     /**
@@ -213,9 +251,11 @@ public class TestPurchaseOrderCommandFactory {
      * @return the {@code MarkPurchaseOrderAsDelivered} instance.
      */
     public static MarkPurchaseOrderAsDelivered markPurchaseOrderAsDeliveredInstance() {
-        return MarkPurchaseOrderAsDelivered.newBuilder()
-                                           .setId(PURCHASE_ORDER_ID)
-                                           .setWhoMarksAsDelivered(USER_ID)
-                                           .build();
+        final MarkPurchaseOrderAsDelivered result = MarkPurchaseOrderAsDelivered
+                .newBuilder()
+                .setId(PURCHASE_ORDER_ID)
+                .setWhoMarksAsDelivered(USER_ID)
+                .build();
+        return result;
     }
 }


### PR DESCRIPTION
In this PR we have changed all classes that relate to the purchase order aggregate as follows:
-Removed unnecessary whitespaces and lines
-Extracted local variables from returning values of methods
-Reformated Javadocs for  public methods and classes
-Changed methods in `PurchaseOrderAggregateRejections` to throw rejections when called
-Changed methods access modifiers to package-private where possible
-Checked `final`  local variable modifiers to be set in all suitable cases
-Refactored tests to meet the requirements above 
